### PR TITLE
feat: reconcile token launcher components and fix stories

### DIFF
--- a/src/components/LoadingIndicator/LoadingIndicator.stories.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.tsx
@@ -8,17 +8,14 @@ export default {
   component: LoadingIndicator
 } as ComponentMeta<typeof LoadingIndicator>;
 
-const Template: ComponentStory<typeof LoadingIndicator> = args => {
-  return (
-    <StoryCard isContrast>
-      <LoadingIndicator {...args} />
-    </StoryCard>
-  );
-};
+const Template: ComponentStory<typeof LoadingIndicator> = args => (
+  <StoryCard isContrast>
+    <LoadingIndicator {...args} />
+  </StoryCard>
+);
 
 export const Default = Template.bind({});
 Default.args = {
   text: 'Howdy something really really long',
-  spinnerPosition: 'right',
-  subtext: 'Hello'
+  spinnerPosition: 'right'
 };

--- a/src/components/StepBar/StepBar.stories.tsx
+++ b/src/components/StepBar/StepBar.stories.tsx
@@ -1,35 +1,38 @@
-import React, { useState } from 'react';
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Step, StepBar } from '.';
+import React, { FC, useState } from 'react';
+import StepBar from './StepBar';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { StoryCard } from '../.storybook';
-
-const STEPS: Step[] = [
-  { id: 'step_1', title: 'Step 1' },
-  { id: 'step_2', title: 'Step 2' },
-  { id: 'step_3', title: 'Step 3' },
-  { id: 'step_4', title: 'Step 4' }
-];
+import { Step } from './StepBar.types';
 
 export default {
-  title: 'Data Display/StepBar',
+  title: 'StepBar',
   component: StepBar
 } as ComponentMeta<typeof StepBar>;
 
-const Template: ComponentStory<typeof StepBar> = args => {
-  const [currentStepId, setCurrentStepId] = useState<Step['id']>(STEPS[STEPS.length - 1].id);
-
-  const onChangeStep = (step: Step) => {
-    setCurrentStepId(step.id);
-  };
+export const Default: ComponentStory<typeof StepBar> = ({ currentStepId, steps }) => {
+  const [step, setStep] = useState(steps.find((x) => x.id === currentStepId));
 
   return (
     <StoryCard isContrast>
-      <StepBar {...args} currentStepId={currentStepId} onChangeStep={onChangeStep} />
+      <StepBar currentStepId={step?.id ?? ""} steps={steps} onChangeStep={(step: Step) => setStep(step)} />
     </StoryCard>
   );
-};
+}
 
-export const Default = Template.bind({});
 Default.args = {
-  steps: STEPS
+    currentStepId: "summary",
+    steps: [
+        {
+            id: "details",
+            title: "Details"
+        },
+        {
+            id: "test",
+            title: "Test"
+        },
+        {
+            id: "summary",
+            title: "Summary"
+        }
+    ]
 };

--- a/src/components/StepBar/StepBar.tsx
+++ b/src/components/StepBar/StepBar.tsx
@@ -46,7 +46,7 @@ export const StepBar: React.FC<StepBarProps> = ({ currentStepId, steps, onChange
           Hide: currentStepIndex > steps.length
         })}
       >
-        {steps[Math.min(steps.length - 1, currentStepIndex)].title}
+        {steps[Math.min(steps.length - 1, currentStepIndex)]?.title}
       </div>
     </div>
   );

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SwitchRadix from './';
-
+import { StoryCard } from '../.storybook/StoryCard';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 export default {
@@ -8,9 +8,14 @@ export default {
   component: SwitchRadix
 } as ComponentMeta<typeof SwitchRadix>;
 
-const Template: ComponentStory<typeof SwitchRadix> = args => <SwitchRadix {...args} />;
+const Template: ComponentStory<typeof SwitchRadix> = args => (
+  <StoryCard isContrast>
+    <SwitchRadix {...args} />
+  </StoryCard>
+);
 
 export const Primary = Template.bind({});
 Primary.args = {
-  id: 'hello'
+  id: "hello",
+  defaultChecked: true
 };

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -1,15 +1,15 @@
 import React, { FC } from 'react';
-
 import * as SwitchRadix from '@radix-ui/react-switch';
 
 type SwitchProps = {
+  id?: string;
   className?: string;
   defaultChecked?: boolean;
 };
 
-const Switch: FC<SwitchProps> = ({ className, ...rest }) => {
+const Switch: FC<SwitchProps> = ({ id, className, ...rest }) => {
   return (
-    <SwitchRadix.Root className={className} id="hello" {...rest}>
+    <SwitchRadix.Root id={id} className={className} {...rest}>
       <SwitchRadix.Thumb />
     </SwitchRadix.Root>
   );

--- a/src/components/Wizard/Wizard.stories.tsx
+++ b/src/components/Wizard/Wizard.stories.tsx
@@ -20,33 +20,40 @@ export const Container: ComponentStory<typeof Wizard.Container> = args => (
 
 export const Loading: ComponentStory<typeof Wizard.Loading> = args => (
   <StoryCard isContrast>
-    <Wizard.Loading {...args}>
-      <p style={{ textAlign: 'center' }}>
-        You can put any content in this container, and it will apply Wizard styling!
-      </p>
-    </Wizard.Loading>
+    <Wizard.Loading {...args} />
   </StoryCard>
 );
+
+Loading.args = {
+  message: "Loading..."
+};
 
 export const Header: ComponentStory<typeof Wizard.Header> = args => (
   <StoryCard isContrast>
     <Wizard.Container>
-      <Wizard.Header {...args} header={'Wizard Header Goes Here'} subHeader={'Some additional info as a subheader'} />
+      <Wizard.Header {...args} />
     </Wizard.Container>
   </StoryCard>
 );
 
+Header.args = {
+  header: "Wizard Header Goes Here",
+  subHeader: "Some additional info as a subheader",
+  sectionDivider: true
+};
+
 export const Confirmation: ComponentStory<typeof Wizard.Confirmation> = args => (
   <StoryCard isContrast>
     <Wizard.Container>
-      <Wizard.Confirmation
-        {...args}
-        message={'Some confirmation text'}
-        isPrimaryButtonActive
-        isSecondaryButtonActive
-        onClickPrimaryButton={() => alert('Clicked confirm')}
-        onClickSecondaryButton={() => alert('Clicked cancel')}
-      />
+      <Wizard.Confirmation {...args} />
     </Wizard.Container>
   </StoryCard>
 );
+
+Confirmation.args = {
+  message: 'Some confirmation text',
+  isPrimaryButtonActive: true,
+  isSecondaryButtonActive: true,
+  onClickPrimaryButton: () => alert('Clicked confirm'),
+  onClickSecondaryButton: () => alert('Clicked cancel')
+};


### PR DESCRIPTION
[Reconcile Token Launcher design components](https://www.notion.so/rational-nomads/Reconcile-Token-Launcher-design-components-3e1014acc59c41658aecc423d086765a)

-----

## 1. Pull request checklist
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card

## 2. PR type
```
- Feature
```

## 3. What is the old behaviour?
- In some instances, the components needed for the coming Token Launcher work are either not present in Storybook or the component is not clearly visible and customizable.

## 4. What is the new behaviour?
- Fixed stories for LoadingIndicator, Switch and Wizard by wrapping in StoryCard's to make children visible and adding control bindings so we can check custom behaviour.
- Addition of default story for StepBar.
- Fixed bug in StepBar when trying to access title of step when steps list length is 0.
- Added missing id prop to Switch component.
