### PR TITLE
feat(grid-card): add new component per Figma

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@radix-ui/react-accessible-icon": "^1.0.0",
-    "@radix-ui/react-aspect-ratio": "^0.1.4",
+    "@radix-ui/react-aspect-ratio": "^1.0.0",
     "@radix-ui/react-dialog": "^0.1.7",
     "@radix-ui/react-dropdown-menu": "^0.1.6",
     "@radix-ui/react-tabs": "^0.1.5",

--- a/src/components/.storybook/HotswapContainer/HotswapContainer.module.scss
+++ b/src/components/.storybook/HotswapContainer/HotswapContainer.module.scss
@@ -1,0 +1,15 @@
+.Container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+
+    padding: 1rem;
+
+    border: 1px dashed yellow;
+
+    box-sizing: border-box;
+
+    height: 100%;
+    width: 100%;
+}

--- a/src/components/.storybook/HotswapContainer/HotswapContainer.tsx
+++ b/src/components/.storybook/HotswapContainer/HotswapContainer.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+
+import styles from './HotswapContainer.module.scss';
+
+export interface HotswapContainerProps {
+  text?: string;
+}
+
+export const HotswapContainer: FC<HotswapContainerProps> = ({ text }) => {
+  return <div className={styles.Container}>{text ?? 'This area is hotswappable.'}</div>;
+};

--- a/src/components/.storybook/HotswapContainer/index.ts
+++ b/src/components/.storybook/HotswapContainer/index.ts
@@ -1,0 +1,2 @@
+export { HotswapContainer } from './HotswapContainer';
+export { HotswapContainerProps } from './HotswapContainer';

--- a/src/components/.storybook/index.ts
+++ b/src/components/.storybook/index.ts
@@ -1,2 +1,3 @@
 export * from './ColorSwatch';
 export * from './StoryCard';
+export * from './HotswapContainer';

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,40 +1,20 @@
 import React, { FC, ReactNode } from 'react';
 
-import Skeleton from '../Skeleton';
+import { AsyncText } from '../../lib/types';
+
+import { TextDetail, TextDetailProps } from '../TextDetail';
+
 import styles from './Card.module.scss';
 
-export interface AsyncText {
-  text?: string | ReactNode;
-  isLoading?: boolean;
-}
-
 export interface CardProps {
-  title: string;
-  value: AsyncText | string | number;
-  bottomText?: AsyncText | string | number;
+  title: TextDetailProps['label'];
+  value: TextDetailProps['primaryText'];
+  bottomText?: TextDetailProps['secondaryText'];
 }
-
-const TEST_ID = {
-  title: 'zui-card-title',
-  value: 'zui-card-value',
-  bottomText: 'zui-card-bottom-text'
-};
 
 const Card: FC<CardProps> = ({ title, value, bottomText }) => (
   <div className={styles.Container}>
-    <label data-id={TEST_ID.title}>{title}</label>
-    <span className={styles.Value}>
-      {typeof value === 'object' ? <>{value.isLoading ? <Skeleton width={'50%'} /> : value.text ?? 'ERR'}</> : value}
-    </span>
-    {bottomText && (
-      <>
-        {typeof bottomText === 'object' ? (
-          <>{bottomText.isLoading ? <Skeleton width={'50%'} /> : <span>bottomText.text</span> ?? 'ERR'}</>
-        ) : (
-          bottomText
-        )}
-      </>
-    )}
+    <TextDetail label={title} primaryText={value} secondaryText={bottomText} />
   </div>
 );
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,6 +1,4 @@
-import React, { FC, ReactNode } from 'react';
-
-import { AsyncText } from '../../lib/types';
+import React, { FC } from 'react';
 
 import { TextDetail, TextDetailProps } from '../TextDetail';
 

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,4 +1,4 @@
 import Card from './Card';
 
-export type { AsyncText, CardProps } from './Card';
+export type { CardProps } from './Card';
 export default Card;

--- a/src/components/GridCard/GridCard.module.scss
+++ b/src/components/GridCard/GridCard.module.scss
@@ -1,0 +1,38 @@
+.Container {
+
+    width: 345px;
+
+    border-radius: 0.5rem;
+    overflow: hidden;
+
+    border: 1px solid grey;
+
+    &:hover {
+        img {
+            transform: scale(1.05);
+        }
+    }
+
+    .ImageContainer {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        overflow: hidden;
+
+        border-radius: 0.5rem;
+
+        img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+
+            transition: transform 0.3s ease;
+
+        }
+    }
+
+    .Content {
+        padding: 1rem;
+    }
+}

--- a/src/components/GridCard/GridCard.stories.tsx
+++ b/src/components/GridCard/GridCard.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { GridCard } from './';
+import NFT from './templates/NFT';
+import { StoryCard, HotswapContainer } from '../.storybook';
+
+export default {
+  title: 'Grid Card',
+  component: GridCard
+} as ComponentMeta<typeof GridCard>;
+
+const Template: ComponentStory<typeof GridCard> = args => {
+  return (
+    <StoryCard isContrast>
+      <GridCard {...args} />
+    </StoryCard>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  children: <HotswapContainer />
+};
+
+export const NFTTemplate = Template.bind({ title: 'NFT Template' });
+NFTTemplate.args = {
+  children: (
+    <NFT
+      buttonText={'Button'}
+      label={'3291503821059321095832190532'}
+      onClickButton={() => alert('yeah')}
+      primaryText={'1,234.00953021593210953291053215321532155'}
+      secondaryText={'$1,234.0032981683921065839532153215321532102168903'}
+      title={'Title638219638921673921863216'}
+      zna={'network.name.3261.3216.312.632153216631.5321.53215.32153216321'}
+    />
+  )
+};

--- a/src/components/GridCard/GridCard.tsx
+++ b/src/components/GridCard/GridCard.tsx
@@ -1,0 +1,23 @@
+import React, { FC, ReactNode } from 'react';
+
+import * as AspectRatio from '@radix-ui/react-aspect-ratio';
+
+import styles from './GridCard.module.scss';
+
+export interface GridCardProps {
+  aspectRatio: AspectRatio.AspectRatioProps['ratio'];
+  children: ReactNode;
+}
+
+const GridCard: FC<GridCardProps> = ({ aspectRatio, children }) => {
+  return (
+    <div className={styles.Container}>
+      <AspectRatio.Root ratio={aspectRatio} className={styles.ImageContainer}>
+        <img src={'https://picsum.photos/200/500'} />
+      </AspectRatio.Root>
+      <div className={styles.Content}>{children}</div>
+    </div>
+  );
+};
+
+export default GridCard;

--- a/src/components/GridCard/index.ts
+++ b/src/components/GridCard/index.ts
@@ -1,0 +1,2 @@
+export { default as GridCard } from './GridCard';
+export type { GridCardProps } from './GridCard';

--- a/src/components/GridCard/templates/NFT.module.scss
+++ b/src/components/GridCard/templates/NFT.module.scss
@@ -1,0 +1,43 @@
+.Details {
+
+    > * {
+        white-space: nowrap;
+        overflow: hidden;
+        display: block;
+        text-overflow: ellipsis;
+    }
+
+    h4 {
+        font-size: 1.5rem;
+        font-weight: bold;
+        margin: 0;
+    }
+
+    span {
+        font-size: 0.75rem;
+        color: grey;
+    }
+}
+
+.Action {
+    display: inline-flex;
+    justify-content: space-between;
+    align-items: center;
+
+    gap: 0.5rem;
+
+    margin-top: 1rem;
+
+    width: 100%;
+
+    > *:last-child {
+        flex-basis: 0px;
+        flex-grow: 1;
+        flex: 1;
+    }
+
+    > *:first-child {
+        min-width: 0;
+    }
+
+}

--- a/src/components/GridCard/templates/NFT.tsx
+++ b/src/components/GridCard/templates/NFT.tsx
@@ -1,0 +1,45 @@
+/* @TODO: this type is used elsewhere - make global? */
+import React, { FC } from 'react';
+
+import { Button } from '../../';
+
+import styles from './NFT.module.scss';
+import { TextDetail, TextDetailProps } from '../../TextDetail';
+
+interface NFTProps extends TextDetailProps {
+  buttonText: string;
+  isButtonDisabled?: boolean;
+  onClickButton: () => void;
+  title: string;
+  zna: string;
+}
+
+const NFT: FC<NFTProps> = ({
+  buttonText,
+  isButtonDisabled,
+  label,
+  onClickButton,
+  primaryText,
+  secondaryText,
+  title,
+  zna
+}) => {
+  return (
+    <div>
+      <div className={styles.Details}>
+        <h4>{title}</h4>
+        <span>0://{zna}</span>
+      </div>
+      <div className={styles.Action}>
+        <TextDetail label={label} primaryText={primaryText} secondaryText={secondaryText} />
+        <div>
+          <Button onPress={onClickButton} isDisabled={isButtonDisabled}>
+            {buttonText}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NFT;

--- a/src/components/TextDetail/TextDetail.module.scss
+++ b/src/components/TextDetail/TextDetail.module.scss
@@ -1,0 +1,25 @@
+@import '../../styles/colors';
+
+.Container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.25rem;
+
+    font-size: 0.75rem;
+
+    color: grey;
+
+    .Value {
+        font-size: 1.125rem;
+        font-weight: bold;
+        color: white;
+    }
+
+    > * {
+        white-space: nowrap;
+        overflow: hidden;
+        display: block;
+        text-overflow: ellipsis;
+    }
+}

--- a/src/components/TextDetail/TextDetail.stories.tsx
+++ b/src/components/TextDetail/TextDetail.stories.tsx
@@ -11,7 +11,7 @@ export default {
 const Template: ComponentStory<typeof TextDetail> = args => {
   return (
     <StoryCard isContrast>
-      <TextDetail primaryText={'Hello'} secondaryText={'Howdy'} label={'Hey'} />
+      <TextDetail {...args} primaryText={'Hello'} secondaryText={'Howdy'} label={'Hey'} />
     </StoryCard>
   );
 };

--- a/src/components/TextDetail/TextDetail.stories.tsx
+++ b/src/components/TextDetail/TextDetail.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { TextDetail } from './';
+import { StoryCard } from '../.storybook';
+
+export default {
+  title: 'Text Detail',
+  component: TextDetail
+} as ComponentMeta<typeof TextDetail>;
+
+const Template: ComponentStory<typeof TextDetail> = args => {
+  return (
+    <StoryCard isContrast>
+      <TextDetail primaryText={'Hello'} secondaryText={'Howdy'} label={'Hey'} />
+    </StoryCard>
+  );
+};
+
+export const Default = Template.bind({});

--- a/src/components/TextDetail/TextDetail.tsx
+++ b/src/components/TextDetail/TextDetail.tsx
@@ -1,0 +1,37 @@
+import { AsyncText } from '../../lib/types';
+import React, { FC } from 'react';
+import Skeleton from '../Skeleton';
+
+import styles from './TextDetail.module.scss';
+
+export interface TextDetailProps {
+  label: string;
+  primaryText: AsyncText | string;
+  secondaryText: AsyncText | string;
+}
+
+const TextDetail: FC<TextDetailProps> = ({ label, primaryText, secondaryText }) => {
+  return (
+    <div className={styles.Container}>
+      <label>{label}</label>
+      <span className={styles.Value}>
+        {typeof primaryText === 'object' ? (
+          <>{primaryText.isLoading ? <Skeleton width={'50%'} /> : primaryText.text ?? 'ERR'}</>
+        ) : (
+          primaryText
+        )}
+      </span>
+      {secondaryText && (
+        <span>
+          {typeof secondaryText === 'object' ? (
+            <>{secondaryText.isLoading ? <Skeleton width={'50%'} /> : secondaryText.text ?? 'ERR'}</>
+          ) : (
+            secondaryText
+          )}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default TextDetail;

--- a/src/components/TextDetail/index.ts
+++ b/src/components/TextDetail/index.ts
@@ -1,0 +1,2 @@
+export { default as TextDetail } from './TextDetail';
+export type { TextDetailProps } from './TextDetail';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,4 @@
+export interface AsyncText {
+  isLoading: boolean;
+  text?: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,13 +2065,13 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.0"
 
-"@radix-ui/react-aspect-ratio@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-0.1.4.tgz#c0a073fafe9e4c150ead5b5eafceada7091566f7"
-  integrity sha512-he70ch76Y6X9BsNYp5Z7ZUpq1008mdoECW39KaNxp19C9R/ary2vWdUNrdXv77tmGNUt+Xyu/vc1CWk//sHUmg==
+"@radix-ui/react-aspect-ratio@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.0.0.tgz#bc8ff46ec2ab221768e17f3bc05cc49d338a4e41"
+  integrity sha512-/QlrIrrcWU8QPz5AccWgKdQGUFw+EKZaxzlH5eWqbOCBTmq0kM1lgaa9EbsmyJwOTtlN0Az9F83lNboQubifwg==
   dependencies:
     "@babel/runtime" "^7.13.10"
-    "@radix-ui/react-primitive" "0.1.4"
+    "@radix-ui/react-primitive" "1.0.0"
 
 "@radix-ui/react-collection@0.1.4":
   version "0.1.4"


### PR DESCRIPTION
- Added GridCard per Figma
- Added a Storybook utility component for showing "hotswappable" areas (as is set in in Figma).
- Moved `AsyncText` to a generic type file, as it's used in multiple components.