### PR TITLE
refactor(modal): remove CSS-in-JS [skip ci]

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -16,9 +16,9 @@
 }
 
 .Content {
-  min-width: 300px;
-  padding: 30px;
-  border-radius: 16px;
+  min-width: 18.75rem; // 300px
+  padding: 1.875rem; // 30px
+  border-radius: 1rem;
   border: 1px solid #{$grey-dark};
 
   background: #{$almost-black};

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -1,0 +1,23 @@
+.Overlay {
+    display: grid;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    place-items: center;
+    overflow-y: auto;
+    z-index: 10000;
+
+    background: rgba(0 0 0 / 0.9);
+}
+
+.Content {
+    min-width: 300px;
+    padding: 30px;
+    border-radius: 16px;
+    border: 1px solid #3b3b3b;
+
+    background: #0a0a0a;
+}

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -1,23 +1,25 @@
+@import '../../styles/colors';
+
 .Overlay {
-    display: grid;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+  display: grid;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 
-    place-items: center;
-    overflow-y: auto;
-    z-index: 10000;
+  place-items: center;
+  overflow-y: auto;
+  z-index: 10000;
 
-    background: rgba(0, 0, 0, 0.9);
+  background: rgba(0, 0, 0, 0.9);
 }
 
 .Content {
-    min-width: 300px;
-    padding: 30px;
-    border-radius: 16px;
-    border: 1px solid #3b3b3b;
+  min-width: 300px;
+  padding: 30px;
+  border-radius: 16px;
+  border: 1px solid #{$grey-dark};
 
-    background: #0a0a0a;
+  background: #{$almost-black};
 }

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -10,7 +10,7 @@
     overflow-y: auto;
     z-index: 10000;
 
-    background: rgba(0 0 0 / 0.9);
+    background: rgba(0, 0, 0, 0.9);
 }
 
 .Content {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -8,32 +8,11 @@ import {
   Trigger as DialogTrigger,
   Content as DialogContent
 } from '@radix-ui/react-dialog';
-import { styled } from '@stitches/react';
 
 import { Button } from '../Button';
 
-// @TODO: use color variables
-
-const Overlay = styled(DialogOverlay, {
-  background: 'rgba(0 0 0 / 0.9)',
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  display: 'grid',
-  placeItems: 'center',
-  overflowY: 'auto',
-  zIndex: 10000
-});
-
-const Content = styled(DialogContent, {
-  minWidth: 300,
-  background: '#0a0a0a',
-  padding: 30,
-  borderRadius: 16,
-  border: '1px solid #3b3b3b'
-});
+import styles from './Modal.module.scss';
+import classNames from 'classnames';
 
 export interface ModalProps extends DialogProps {
   className?: string;
@@ -49,9 +28,9 @@ export const Modal: React.FC<ModalProps> = ({ className, children, trigger, ...r
         </DialogTrigger>
       )}
       <DialogPortal>
-        <Overlay>
-          <Content className={className}>{children}</Content>
-        </Overlay>
+        <DialogOverlay className={styles.Overlay}>
+          <DialogContent className={classNames(className, styles.Content, 'content')}>{children}</DialogContent>
+        </DialogOverlay>
       </DialogPortal>
     </DialogRoot>
   );

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -29,7 +29,7 @@ export const Modal: React.FC<ModalProps> = ({ className, children, trigger, ...r
       )}
       <DialogPortal>
         <DialogOverlay className={styles.Overlay}>
-          <DialogContent className={classNames(className, styles.Content, 'content')}>{children}</DialogContent>
+          <DialogContent className={classNames(className, styles.Content)}>{children}</DialogContent>
         </DialogOverlay>
       </DialogPortal>
     </DialogRoot>

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -7,6 +7,7 @@ $grey: #808080;
 $grey-lighter-2: #bfbfbf;
 $grey-lighter-3: #d9d9d9;
 $grey-lighter-4: #f2f2f2;
+$grey-dark: #3b3b3b;
 $grey-darker: linear-gradient(0deg, #404040, #404040), $grey;
 
 // White

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,6 +3653,11 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
- Removes old CSS-in-JS styling from the `Modal` component.
- Adds `Modal.module.scss` for styling