### PR TITLE
test(modal): improve coverage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
   },
   "overrides": [
     {
-      "files": ["*.js", ",*.jsx", "*.ts", "*.tsx"],
+      "files": ["*.js", "*.jsx", "*.ts", "*.tsx"],
       "rules": {
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "react/display-name": 0,
@@ -110,6 +110,13 @@
       "files": ["*.stories.tsx"],
       "rules": {
         "import/no-default-export": "off"
+      }
+    },
+    // Test files
+    {
+      "files": ["*.test.tsx"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
       }
     }
   ]

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -45,7 +45,7 @@ afterEach(() => {
 const renderComponent = (props?: ModalProps) => render(<Modal {...DEFAULT_PROPS} {...props} />);
 
 test('should render string trigger as a button', () => {
-  const { getByText, getByTestId } = renderComponent();
+  const { getByTestId } = renderComponent();
   const trigger = getByTestId('trigger');
   expect(mockRadixTrigger).toBeCalledWith(expect.objectContaining({ asChild: true }));
   expect(trigger.textContent).toBe(MOCK_TRIGGER);

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,13 +1,108 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { cleanup, getByRole, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
 import { Modal, ModalProps } from '.';
 
-const mockTrigger = 'Mock Trigger';
+const MOCK_TRIGGER = 'Mock Trigger';
+const DEFAULT_PROPS = { trigger: MOCK_TRIGGER };
 
-const renderComponent = (props: ModalProps) => render(<Modal {...props} />);
+const mockRadixOverlay = jest.fn();
+const mockRadixRoot = jest.fn();
+const mockRadixPortal = jest.fn();
+const mockRadixTrigger = jest.fn();
+const mockRadixContent = jest.fn();
 
-test('should render trigger', () => {
-  const { getByText } = renderComponent({ trigger: mockTrigger });
-  const trigger = getByText(mockTrigger);
-  expect(trigger).toBeInTheDocument();
+/* Mock Radix Dialog primitives so we can skip testing them */
+jest.mock('@radix-ui/react-dialog', () => ({
+  Overlay: (props: any) => {
+    mockRadixOverlay(props);
+    return <div data-testid="overlay">{props.children}</div>;
+  },
+  Root: (props: any) => {
+    mockRadixRoot(props);
+    return <div data-testid="root">{props.children}</div>;
+  },
+  Portal: (props: any) => {
+    mockRadixPortal(props);
+    return <div data-testid="portal">{props.children}</div>;
+  },
+  Trigger: (props: any) => {
+    mockRadixTrigger(props);
+    return <div data-testid="trigger">{props.children}</div>;
+  },
+  Content: (props: any) => {
+    mockRadixContent(props);
+    return <div data-testid="content">{props.children}</div>;
+  }
+}));
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
+
+const renderComponent = (props?: ModalProps) => render(<Modal {...DEFAULT_PROPS} {...props} />);
+
+test('should render string trigger as a button', () => {
+  const { getByText, getByTestId } = renderComponent();
+  const trigger = getByTestId('trigger');
+  expect(mockRadixTrigger).toBeCalledWith(expect.objectContaining({ asChild: true }));
+  expect(trigger.textContent).toBe(MOCK_TRIGGER);
+  expect(trigger.childNodes.length).toBe(1);
+  expect(getByRole(trigger, 'button')).toBeInTheDocument();
+});
+
+test('should render ReactNode trigger as a ReactNode', () => {
+  const { getByText, getByTestId } = renderComponent({ trigger: <p>{MOCK_TRIGGER}</p> });
+  const trigger = getByTestId('trigger');
+  expect(mockRadixTrigger).toBeCalledWith(expect.objectContaining({ asChild: true }));
+  expect(trigger.textContent).toBe(MOCK_TRIGGER);
+  expect(trigger.childNodes.length).toBe(1);
+  expect(getByText(MOCK_TRIGGER).nodeName).toBe('P');
+});
+
+test('should render children in Radix Content primitive', () => {
+  renderComponent({ children: 'mock-children' });
+  expect(mockRadixContent).toHaveBeenCalledWith(expect.objectContaining({ children: 'mock-children' }));
+});
+
+test('should not render Trigger when trigger prop is undefined', () => {
+  renderComponent({ trigger: undefined });
+  expect(mockRadixTrigger).toBeCalledTimes(0);
+});
+
+test('should apply className prop to Content', () => {
+  renderComponent({ className: 'mock-class' });
+  expect(mockRadixContent).toHaveBeenCalledTimes(1);
+  expect(mockRadixContent.mock.calls[0][0].className.split(' ').includes('mock-class')).toBe(true);
+});
+
+test('should apply Radix DialogProps to the Radix DialogRoot', () => {
+  renderComponent({ open: true });
+  expect(mockRadixRoot).toHaveBeenCalledWith(expect.objectContaining({ open: true }));
+});
+
+test('should not render Trigger as a child of Portal', () => {
+  const { getByTestId } = renderComponent();
+
+  const root = getByTestId('root');
+  expect(root).toBeInTheDocument();
+  expect(root.childElementCount).toBe(2);
+
+  const ids = Array.from(root.children).map(c => c.getAttribute('data-testid'));
+  expect(ids).toContain('trigger');
+  expect(ids).toContain('portal');
+});
+
+test('should render Overlay and Content in Portal with correct nesting', () => {
+  const { getByTestId } = renderComponent();
+
+  const portal = getByTestId('portal');
+  expect(portal.childElementCount).toBe(1);
+  expect(portal.children[0].getAttribute('data-testid')).toContain('overlay');
+
+  const overlay = getByTestId('overlay');
+  expect(overlay.childElementCount).toBe(1);
+  expect(overlay.children[0].getAttribute('data-testid')).toContain('content');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,6 +3653,11 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
Added tests for `Modal`:
- should render string trigger as a button
- should render ReactNode trigger as a ReactNode
- should render children in Radix Content primitive
- should not render Trigger when trigger prop is undefined 
- should apply className prop to Content
- should apply Radix DialogProps to the Radix DialogRoot
- should not render Trigger as a child of Portal
- should render Overlay and Content in Portal with correct nesting 
