### PR TITLE
feat: Add ThemeEngine component (portal)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,7 +10,7 @@ export const decorators = [
     return (
       <MemoryRouter initialEntries={['/']}>
         <ZUIProvider>
-          <ThemeEngine theme={theme} />
+          <ThemeEngine variant={theme} />
           <Story />
         </ZUIProvider>
       </MemoryRouter>

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@radix-ui/react-aspect-ratio": "^0.1.4",
     "@radix-ui/react-dialog": "^0.1.7",
     "@radix-ui/react-dropdown-menu": "^0.1.6",
+    "@radix-ui/react-portal": "^1.0.0",
     "@radix-ui/react-tabs": "^0.1.5",
     "@radix-ui/react-tooltip": "^1.0.0",
     "@react-aria/button": "^3.5.0",

--- a/src/components/ThemeEngine/StyleEngine.test.tsx
+++ b/src/components/ThemeEngine/StyleEngine.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { StyleEngine } from './StyleEngine';
+import { render } from '@testing-library/react';
+
+let mockPortal = jest.fn();
+
+jest.mock('@radix-ui/react-portal', () => ({
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  Root: (props: any) => {
+    mockPortal(props);
+    return <div data-testid="mock-portal">{props.children}</div>;
+  }
+}));
+
+jest.spyOn(global.console, 'warn');
+
+describe('<StyleEngine />', () => {
+  describe('when using Radix Portal (@radix-ui/react-portal)', () => {
+    const { getByTestId } = render(<StyleEngine />);
+
+    test('should render a style element in portal', () => {
+      const head = getByTestId('mock-portal');
+      expect(head.children.length).toBe(1);
+      expect(head.children[0].nodeName).toBe('STYLE');
+    });
+
+    test('should set isChild=true on portal', () => {
+      expect(mockPortal).toHaveBeenCalledWith(expect.objectContaining({ asChild: true }));
+    });
+
+    test('should set container=document.head on portal', () => {
+      expect(mockPortal).toHaveBeenCalledWith(expect.objectContaining({ container: document.head }));
+    });
+  });
+
+  describe('when all CSS is valid', () => {
+    test('should add formatted CSS variables to :root', () => {
+      const styles = { primaryColor1: '#000', alphaPrimary1: 'rgba(177, 78, 255, 0.03)' };
+      const expectedCSS = ':root { --zui-primary-color-1: #000; --zui-alpha-primary-1: rgba(177, 78, 255, 0.03); }';
+
+      const { container } = render(<StyleEngine styles={styles} />);
+      const style = container.querySelector('#zui-theme-variables');
+      expect(style.innerHTML).toBe(expectedCSS);
+    });
+  });
+
+  describe('when passing invalid CSS', () => {
+    const styles = { primary: 'styleengine', secondary: 'red' };
+    const expectedCSS = ':root { --zui-secondary: red; }';
+    let container: HTMLElement;
+    beforeEach(() => {
+      jest.resetAllMocks();
+      const result = render(<StyleEngine styles={styles} />);
+      container = result.container;
+    });
+
+    test('should filter invalid CSS', () => {
+      const style = container.querySelector('#zui-theme-variables');
+      expect(style.innerHTML).toBe(expectedCSS);
+    });
+
+    test('should warn in console', () => {
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/ThemeEngine/StyleEngine.tsx
+++ b/src/components/ThemeEngine/StyleEngine.tsx
@@ -1,0 +1,76 @@
+import { CSS_PREFIX } from '../constants';
+import { kebabCase } from 'lodash';
+import React, { ReactNode, useMemo } from 'react';
+
+import { Root as PortalRoot } from '@radix-ui/react-portal';
+
+/**
+ * Validates a CSS color variable.
+ * @param value The value to validate
+ */
+const isColor = (value: string) => {
+  const s = new Option().style;
+  s.background = value;
+  return s.background !== '';
+};
+
+/**
+ * Adds children to document.head via Radix Portal.
+ * @param children The children to add to document.head
+ */
+const HeadPortal = ({ children }: { children: ReactNode }) => {
+  return (
+    <PortalRoot asChild={true} container={document.head}>
+      {children}
+    </PortalRoot>
+  );
+};
+
+type Styles = {
+  [key: string]: string;
+};
+
+/**
+ * Converts an object of key/value pairs into a CSS string.
+ * Values are validated to ensure they are valid CSS color variables.
+ * Variable names are formated to kebab-case and have --zui appended.
+ * @param styles
+ */
+const mapStylesToCSS = (styles: Styles): string => {
+  return Object.entries(styles)
+    .map(([style, value]) => {
+      // Theme values are currently all colors - check they are valid
+      // colors before adding them to the output styles
+      if (isColor(value)) {
+        return `--${CSS_PREFIX}-${kebabCase(style)}: ${value};`;
+      } else {
+        console.warn('CSS variable not supported', style, value);
+        return;
+      }
+    })
+    .join(' ')
+    .toString()
+    .trim();
+};
+
+export interface StyleEngineProps {
+  styles?: Styles;
+}
+
+/**
+ * Adds an array of CSS key value pairs to a <style> tag in <head>.
+ * Also appends converts CSS keys to the format --zui-<key-as-kebab-case>
+ * @param styles
+ * @constructor
+ */
+export const StyleEngine = ({ styles }: StyleEngineProps) => {
+  const mappedStyles = useMemo(() => {
+    return styles ? mapStylesToCSS(styles) : '';
+  }, [styles]);
+
+  return (
+    <HeadPortal>
+      <style id={'zui-theme-variables'} type={'text/css'}>{`:root { ${mappedStyles} }`}</style>
+    </HeadPortal>
+  );
+};

--- a/src/components/ThemeEngine/ThemeEngine.test.tsx
+++ b/src/components/ThemeEngine/ThemeEngine.test.tsx
@@ -1,35 +1,37 @@
 import React from 'react';
+
 import { render } from '@testing-library/react';
-import { DEFAULT_THEME_VARIANT, Theme, ThemeEngine, themes, ThemeVariant, toCssVariableName } from '.';
+import { ThemeEngine } from './ThemeEngine';
+import { ThemeVariant } from './ThemeEngine.constants';
+import { themes } from './themes';
 
-const compareTheme = (theme: Theme, properties: CSSStyleDeclaration) => {
-  for (const color in theme) {
-    const value = properties.getPropertyValue(toCssVariableName(color));
-    const expected = theme[color as keyof Theme];
-    expect(value).toEqual(expected);
+let mockStyleEngine = jest.fn();
+
+jest.mock('./StyleEngine', () => ({
+  StyleEngine: ({ styles }: { styles: string }) => {
+    mockStyleEngine(styles);
+    return <div />;
   }
-};
+}));
 
-test('should set global CSS variables for theme from props', () => {
-  const { rerender } = render(<ThemeEngine theme={ThemeVariant.Light} />);
+describe('<ThemeEngine />', () => {
+  describe('variant', () => {
+    test('should default to dark variant', () => {
+      render(<ThemeEngine />);
+      expect(mockStyleEngine).toHaveBeenCalledWith(themes[ThemeVariant.Dark]);
+    });
 
-  compareTheme(themes[ThemeVariant.Light], getComputedStyle(document.documentElement));
+    // Testing both of the variants currently, as we only have two variants.
+    // As we add more variants, we should make these tests more generic.
 
-  rerender(<ThemeEngine theme={ThemeVariant.Dark} />);
+    test('should render StyleEngine with dark styles when variant is Dark', () => {
+      render(<ThemeEngine variant={ThemeVariant.Dark} />);
+      expect(mockStyleEngine).toHaveBeenCalledWith(themes[ThemeVariant.Dark]);
+    });
 
-  compareTheme(themes[ThemeVariant.Dark], getComputedStyle(document.documentElement));
-});
-
-test('should use default theme from ThemeEngine.constants.ts', () => {
-  render(<ThemeEngine />);
-
-  compareTheme(themes[DEFAULT_THEME_VARIANT], getComputedStyle(document.documentElement));
-});
-
-describe('toCssVariableName', () => {
-  it('should correctly format CSS variable names', () => {
-    expect(toCssVariableName('primary1')).toEqual('--zui-primary-1');
-    expect(toCssVariableName('primary')).toEqual('--zui-primary');
-    expect(toCssVariableName('shouldBeKebabCase')).toEqual('--zui-should-be-kebab-case');
+    test('should render StyleEngine with light styles when variant is Light', () => {
+      render(<ThemeEngine variant={ThemeVariant.Light} />);
+      expect(mockStyleEngine).toHaveBeenCalledWith(themes[ThemeVariant.Light]);
+    });
   });
 });

--- a/src/components/ThemeEngine/ThemeEngine.tsx
+++ b/src/components/ThemeEngine/ThemeEngine.tsx
@@ -1,32 +1,19 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { kebabCase } from 'lodash';
-import type { Theme } from './ThemeEngine.types';
-import { CSS_PREFIX } from '../constants';
 import { DEFAULT_THEME_VARIANT, ThemeVariant } from './ThemeEngine.constants';
 import { themes } from './themes';
 
+import { StyleEngine } from './StyleEngine';
+
 export interface ThemeEngineProps {
-  theme?: ThemeVariant;
+  variant?: ThemeVariant;
 }
 
 /**
- * Converts a string to a zUI CSS variable name
- * e.g. toCssVariableName('primary1') -> 'zui-primary-1'
- * @param name
+ * ThemeEngine is responsible for sending the correct theme to StyleEngine.
+ * @param variant The theme variant to use
+ * @constructor
  */
-export const toCssVariableName = (name: string) => {
-  return `--${CSS_PREFIX}-${kebabCase(name)}`;
-};
-
-export const ThemeEngine = ({ theme = DEFAULT_THEME_VARIANT }: ThemeEngineProps) => {
-  const setThemeVars = () => {
-    Object.keys(themes[theme]).forEach((color: keyof Theme) => {
-      document.documentElement.style.setProperty(toCssVariableName(color), themes[theme][color]);
-    });
-  };
-
-  useEffect(setThemeVars, [theme]);
-
-  return <></>;
+export const ThemeEngine = ({ variant = DEFAULT_THEME_VARIANT }: ThemeEngineProps) => {
+  return <StyleEngine styles={themes[variant]} />;
 };

--- a/src/components/ThemeEngine/themes.ts
+++ b/src/components/ThemeEngine/themes.ts
@@ -94,10 +94,8 @@ export const themes: Record<ThemeVariant, Theme> = {
 
     // Gradients
     gradientPurple1: 'linear-gradient(223deg, #421349 14.62%, #0D0416 36.73%, #0B060E 59.58%, #2B0659 85.38%)',
-    gradientPurple2:
-      'radial-gradient(66.52% 66.52% at 0% 0%, #26072D 0%, rgba(38, 7, 45, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(93.63% 93.63% at 100% 0%, #9D0097 0%, rgba(157, 0, 151, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(91.27% 91.27% at 112.3% 83.55%, #52A9FF 0%, rgba(82, 169, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(65.88% 65.88% at -1.79% 99.21%, #4F0895 0%, rgba(79, 8, 149, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #290634',
-    gradientPurple3:
-      'radial-gradient(66.52% 66.52% at 0% 0%, #B900E3 0%, rgba(111, 25, 131, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(93.63% 93.63% at 100% 0%, #DE1CD7 0%, rgba(232, 0, 223, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(99.71% 99.71% at 104.51% 75.11%, #71B8FF 0%, rgba(116, 186, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(65.88% 65.88% at -1.79% 99.21%, #7D12E7 0%, rgba(162, 68, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #290634',
+    gradientPurple2: 'radial-gradient(66.52% 66.52% at 0% 0%, #26072D 0%, rgba(38, 7, 45, 0) 100%)',
+    gradientPurple3: 'radial-gradient(66.52% 66.52% at 0% 0%, #B900E3 0%, rgba(111, 25, 131, 0) 100%)',
     gradientBlue1: 'linear-gradient(90deg, #5257FF 0%, #52CBFF 100%)',
     gradientBlue2: 'linear-gradient(90deg, #5257FF 0%, #52CBFF 100%)',
     gradientBlue3: 'linear-gradient(90deg, #5257FF 0%, #52CBFF 100%)',
@@ -233,10 +231,8 @@ export const themes: Record<ThemeVariant, Theme> = {
 
     // Gradients
     gradientPurple1: 'linear-gradient(219deg, #F5DAFF 14.45%, #F6EFF9 36.67%, #F9EFFF 59.63%, #EDD6FF 85.55%)',
-    gradientPurple2:
-      'radial-gradient(66.52% 66.52% at 0% 0%, #26072D 0%, rgba(38, 7, 45, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(93.63% 93.63% at 100% 0%, #9D0097 0%, rgba(157, 0, 151, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(91.27% 91.27% at 112.3% 83.55%, #52A9FF 0%, rgba(82, 169, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(65.88% 65.88% at -1.79% 99.21%, #4F0895 0%, rgba(79, 8, 149, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #290634',
-    gradientPurple3:
-      'radial-gradient(66.52% 66.52% at 0% 0%, #B900E3 0%, rgba(111, 25, 131, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(93.63% 93.63% at 100% 0%, #DE1CD7 0%, rgba(232, 0, 223, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(99.71% 99.71% at 104.51% 75.11%, #71B8FF 0%, rgba(116, 186, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, radial-gradient(65.88% 65.88% at -1.79% 99.21%, #7D12E7 0%, rgba(162, 68, 255, 0) 100%) /* warning: gradient uses a rotation that is not supported by CSS and may not behave as expected */, #290634',
+    gradientPurple2: 'radial-gradient(66.52% 66.52% at 0% 0%, #26072D 0%, rgba(38, 7, 45, 0) 100%)',
+    gradientPurple3: 'radial-gradient(66.52% 66.52% at 0% 0%, #B900E3 0%, rgba(111, 25, 131, 0) 100%)',
     gradientBlue1: 'linear-gradient(90deg, #5257FF 0%, #52CBFF 100%)',
     gradientBlue2: 'linear-gradient(90deg, #5257FF 0%, #52CBFF 100%)',
     gradientBlue3: 'linear-gradient(90deg, #5257FF 0%, #52CBFF 100%)',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,7 +2269,7 @@
     "@radix-ui/react-primitive" "0.1.4"
     "@radix-ui/react-use-layout-effect" "0.1.0"
 
-"@radix-ui/react-portal@1.0.0":
+"@radix-ui/react-portal@1.0.0", "@radix-ui/react-portal@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.0.tgz#7220b66743394fabb50c55cb32381395cc4a276b"
   integrity sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==


### PR DESCRIPTION
Variation of #20.

- Uses `@radix-ui/react-portal` to append a `<style>` node to `<head>`.
- Splits `ThemeEngine` and `StyleEngine` into two parts - the former for selecting a theme, the latter for converting a theme into CSS.
- Better testing.