### PR TITLE
refactor(GridCard/templates): update NFT template to take optional button prop

### DIFF
--- a/src/components/GridCard/GridCard.stories.tsx
+++ b/src/components/GridCard/GridCard.stories.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { GridCard } from './';
 import { NFT } from './templates/NFT';
+import { Button } from '../../components/Button';
 import { StoryCard, HotswapContainer } from '../.storybook';
 
 export default {
   title: 'Data Display/Cards/Grid Card',
   component: GridCard
 } as ComponentMeta<typeof GridCard>;
+
+const CustomButton = <Button onPress={() => alert('Clicked')}>Custom</Button>;
 
 const Template: ComponentStory<typeof GridCard> = args => {
   return (
@@ -31,13 +34,12 @@ export const NFTTemplate = Template.bind({ title: 'NFT Template' });
 NFTTemplate.args = {
   children: (
     <NFT
-      buttonText={'Bid'}
       label={'Top Bid ($MOCK)'}
-      onClickButton={() => alert('yeah')}
       primaryText={'1,234.50'}
       secondaryText={'$1,234.50'}
       title={'Lorem Ipsum'}
       zna={'lorem.ipsum'}
+      button={CustomButton}
     />
   )
 };

--- a/src/components/GridCard/templates/NFT.test.tsx
+++ b/src/components/GridCard/templates/NFT.test.tsx
@@ -19,19 +19,17 @@ const mockButton = jest.fn();
 jest.mock('../../Button', () => ({
   Button: (props: ButtonProps) => {
     mockButton(props);
-    return <div />;
+    return <div>Mock Button</div>;
   }
 }));
 
 const DEFAULT_PROPS: NFTProps = {
-  buttonText: '',
-  isButtonDisabled: false,
   label: '',
-  onClickButton: undefined,
   primaryText: '',
   secondaryText: undefined,
   title: '',
-  zna: ''
+  zna: '',
+  button: undefined
 };
 
 beforeEach(() => {
@@ -76,32 +74,16 @@ describe('<NFT />', () => {
   });
 
   describe('Button', () => {
-    test('should forward buttonText to Button children', () => {
-      render(<NFT {...DEFAULT_PROPS} buttonText={'mock button text'} />);
-      expect(mockButton).toHaveBeenCalledWith(
-        expect.objectContaining({
-          children: 'mock button text'
-        })
-      );
+    test('should not render button by default', () => {
+      const { container } = render(<NFT {...DEFAULT_PROPS} />);
+
+      expect(container.getElementsByClassName('Button').length).toBe(0);
     });
 
-    test('should forward isButtonDisabled to Button', () => {
-      render(<NFT {...DEFAULT_PROPS} isButtonDisabled={true} />);
-      expect(mockButton).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isDisabled: true
-        })
-      );
-    });
+    test('should render button ', () => {
+      const { container } = render(<NFT {...DEFAULT_PROPS} button={mockButton} />);
 
-    test('should forward onClickButton to Button', () => {
-      const mockOnClickButton = jest.fn();
-      render(<NFT {...DEFAULT_PROPS} onClickButton={mockOnClickButton} />);
-      expect(mockButton).toHaveBeenCalledWith(
-        expect.objectContaining({
-          onPress: mockOnClickButton
-        })
-      );
+      expect(container.getElementsByClassName('Button').length).toBe(1);
     });
   });
 });

--- a/src/components/GridCard/templates/NFT.tsx
+++ b/src/components/GridCard/templates/NFT.tsx
@@ -1,32 +1,20 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 
-import { Button } from '../../Button';
+import { AsyncText } from '../../../lib/types';
+
 import { TextStack, TextStackProps } from '../../TextStack';
+import { MaybeSkeletonText } from '../../SkeletonText';
 
 import styles from './NFT.module.scss';
-import { AsyncText } from '../../../lib/types';
-import { MaybeSkeletonText } from '../../SkeletonText';
 
 export interface NFTProps extends TextStackProps {
   className?: string;
-  buttonText: string;
-  isButtonDisabled?: boolean;
-  onClickButton: () => void;
+  button?: ReactNode;
   title: string | AsyncText;
   zna: string;
 }
 
-export const NFT: FC<NFTProps> = ({
-  className,
-  buttonText,
-  isButtonDisabled,
-  label,
-  onClickButton,
-  primaryText,
-  secondaryText,
-  title,
-  zna
-}) => {
+export const NFT: FC<NFTProps> = ({ className, button, label, primaryText, secondaryText, title, zna }) => {
   return (
     <div className={className}>
       <div className={styles.Details}>
@@ -35,11 +23,7 @@ export const NFT: FC<NFTProps> = ({
       </div>
       <div className={styles.Action}>
         <TextStack label={label} primaryText={primaryText} secondaryText={secondaryText} />
-        <div className={styles.Button}>
-          <Button onPress={onClickButton} isDisabled={isButtonDisabled}>
-            {buttonText}
-          </Button>
-        </div>
+        {button && <div className={styles.Button}>{button}</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
- updated NFT template to take a `button` prop that can be passed down, or, not included if required