### PR TITLE
refactor: update text stack prop type to take react node

### DIFF
--- a/src/components/SkeletonText/SkeletonText.tsx
+++ b/src/components/SkeletonText/SkeletonText.tsx
@@ -1,4 +1,4 @@
-import React, { createElement } from 'react';
+import React, { createElement, ReactNode } from 'react';
 
 import { AsyncText, HTMLTextElement } from '../../lib/types';
 import { Skeleton, SkeletonProps } from '../Skeleton';
@@ -59,7 +59,7 @@ export const SkeletonText = ({
  * Props specific to MaybeSkeletonText
  */
 interface MaybeProps {
-  text: string | AsyncProps['asyncText'];
+  text: ReactNode | AsyncProps['asyncText'];
 }
 
 export type MaybeSkeletonTextProps = SharedProps & MaybeProps;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
+import { ReactNode } from 'react';
 export interface AsyncText {
   isLoading: boolean;
-  text?: string;
+  text?: ReactNode;
   errorText?: string;
   errorClassName?: string;
 }


### PR DESCRIPTION
- update 'text' prop type to ReactNode. This will prevent error when passing in components such as `ArrowLink` etc