### PR TITLE
feat: add Image component

### DIFF
--- a/src/components/GridCard/GridCard.module.scss
+++ b/src/components/GridCard/GridCard.module.scss
@@ -6,7 +6,7 @@
     border: 1px solid #404040;
 
     &:hover {
-        img {
+        .Image {
             transform: scale(1.05);
         }
     }

--- a/src/components/GridCard/GridCard.test.tsx
+++ b/src/components/GridCard/GridCard.test.tsx
@@ -13,6 +13,15 @@ jest.mock('@radix-ui/react-aspect-ratio', () => ({
   }
 }));
 
+const mockImage = jest.fn();
+
+jest.mock('../Image', () => ({
+  Image: (props: any) => {
+    mockImage(props);
+    return <div data-testid="mock-image" />;
+  }
+}));
+
 const DEFAULT_PROPS = {
   aspectRatio: 1,
   imageAlt: '',
@@ -49,13 +58,13 @@ describe('<GridCard />', () => {
     });
 
     test('should pass alt prop to img element', () => {
-      render(<GridCard {...DEFAULT_PROPS} imageAlt={'mock-alt'} imageSrc={'mock-src'} />);
-      expect(screen.getByRole('img')).toHaveAttribute('alt', 'mock-alt');
+      render(<GridCard {...DEFAULT_PROPS} imageAlt={'mock alt'} imageSrc={'mock-src'} />);
+      expect(mockImage).toHaveBeenCalledWith(expect.objectContaining({ alt: 'mock alt' }));
     });
 
     test('should pass src prop to img element', () => {
       render(<GridCard {...DEFAULT_PROPS} imageSrc={'mock-src'} />);
-      expect(screen.getByRole('img')).toHaveAttribute('src', 'mock-src');
+      expect(mockImage).toHaveBeenCalledWith(expect.objectContaining({ src: 'mock-src' }));
     });
   });
 });

--- a/src/components/GridCard/GridCard.tsx
+++ b/src/components/GridCard/GridCard.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 
 import { AspectRatioProps, Root as AspectRatioRoot } from '@radix-ui/react-aspect-ratio';
 import { Skeleton } from '../Skeleton';
+import { Image } from '../Image';
 
 import classNames from 'classnames';
 import styles from './GridCard.module.scss';
@@ -19,7 +20,11 @@ export const GridCard = ({ aspectRatio = 1, className, children, imageAlt, image
   return (
     <div onClick={onClick} className={classNames(styles.Container, className)}>
       <AspectRatioRoot ratio={aspectRatio} className={styles.ImageContainer}>
-        {imageSrc ? <img src={imageSrc} alt={imageAlt} /> : <Skeleton width={'100%'} height={'100%'} />}
+        {imageSrc ? (
+          <Image className={styles.Image} src={imageSrc} alt={imageAlt} />
+        ) : (
+          <Skeleton width={'100%'} height={'100%'} />
+        )}
       </AspectRatioRoot>
       <div className={styles.Content}>{children}</div>
     </div>

--- a/src/components/Image/Image.module.scss
+++ b/src/components/Image/Image.module.scss
@@ -1,0 +1,55 @@
+@keyframes disappear {
+    from {
+        //opacity: 1;
+        visibility: visible;
+    }
+    to {
+        //opacity: 0;
+        visibility: hidden;
+    }
+}
+
+.Container {
+    position: relative;
+
+    > * {
+        border-radius: inherit;
+        height: 100%;
+        width: 100%;
+    }
+
+    .Image {
+        opacity: 0;
+        z-index: 0;
+    }
+
+    &[data-is-cached] {
+        * {
+            transition: none;
+        }
+    }
+
+    &[data-status="loaded"] {
+        .Image {
+            opacity: 1;
+            transition: opacity 0.4s ease;
+        }
+
+        .Skeleton {
+            // hide skeleton on a 0.4s delay
+            animation: disappear 0.4s ease 0.4s forwards;
+        }
+    }
+
+    .Skeleton {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: -1;
+        opacity: 1;
+
+        border-radius: inherit !important;
+    }
+}

--- a/src/components/Image/Image.module.scss
+++ b/src/components/Image/Image.module.scss
@@ -1,10 +1,8 @@
 @keyframes disappear {
     from {
-        //opacity: 1;
         visibility: visible;
     }
     to {
-        //opacity: 0;
         visibility: hidden;
     }
 }

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Image } from './';
+import { StoryCard } from '../.storybook';
+
+export default {
+  title: 'Data Display/Image',
+  component: Image
+} as ComponentMeta<typeof Image>;
+
+const Template: ComponentStory<typeof Image> = args => (
+  <StoryCard isContrast>
+    <div style={{ width: 200, height: 300 }}>
+      <Image {...args} />
+    </div>
+  </StoryCard>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  src: 'https://picsum.photos/200/300',
+  alt: 'random image'
+};

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { Image, ImageProps } from './';
+
+const DEFAULT_PROPS: ImageProps = {
+  alt: 'mock alt'
+};
+
+const DEFAULT_IMAGE_URL = 'https://picsum.photos/1/1';
+
+const mockSkeleton = jest.fn();
+
+jest.mock('../Skeleton', () => ({
+  Skeleton: (props: any) => {
+    mockSkeleton(props);
+    return <div data-testid={'zui-image-skeleton'} />;
+  }
+}));
+
+beforeEach(() => {
+  mockSkeleton.mockClear();
+});
+
+describe('<Image />', () => {
+  test('should render a skeleton when image is loading or undefined', () => {
+    render(<Image {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('zui-image-skeleton')).toBeVisible();
+  });
+
+  test('should pass onLoad to image', () => {
+    const onLoad = jest.fn();
+    render(<Image {...DEFAULT_PROPS} src={DEFAULT_IMAGE_URL} onLoad={onLoad} />);
+    expect(onLoad).not.toHaveBeenCalled();
+    const img = screen.getByTestId('zui-image-img');
+    img.dispatchEvent(new Event('load'));
+    expect(onLoad).toHaveBeenCalled();
+  });
+
+  test('should pass onError to image', () => {
+    const onError = jest.fn();
+    render(<Image {...DEFAULT_PROPS} src={DEFAULT_IMAGE_URL} onError={onError} />);
+    const image = screen.getByTestId('zui-image-img');
+    image.dispatchEvent(new Event('error'));
+    expect(onError).toHaveBeenCalled();
+  });
+
+  test('should pass alt to image', () => {
+    render(<Image {...DEFAULT_PROPS} alt={'mock alt'} />);
+    expect(screen.getByTestId('zui-image-img')).toHaveAttribute('alt', 'mock alt');
+  });
+
+  describe('class names', () => {
+    test('should pass className to the root element', () => {
+      const { container } = render(<Image {...DEFAULT_PROPS} className={'test-class'} />);
+      expect(container.firstChild).toHaveClass('test-class');
+    });
+
+    test('should apply Container class name to root element', () => {
+      const { container } = render(<Image {...DEFAULT_PROPS} />);
+      expect(container.firstChild).toHaveClass('Container');
+    });
+
+    test('should apply Image class name to image element', () => {
+      render(<Image {...DEFAULT_PROPS} />);
+      expect(screen.getByTestId('zui-image-img')).toHaveClass('Image');
+    });
+
+    test('should apply Skeleton class to skeleton', () => {
+      render(<Image {...DEFAULT_PROPS} />);
+      expect(mockSkeleton).toHaveBeenCalledWith(expect.objectContaining({ className: 'Skeleton' }));
+    });
+  });
+});

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect } from 'react';
+
+import { Skeleton } from '../Skeleton';
+
+import styles from './Image.module.scss';
+import classNames from 'classnames';
+
+export interface ImageProps {
+  alt: string;
+  src?: string;
+  className?: string;
+  objectFit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+  onLoad?: () => void;
+  onError?: () => void;
+}
+
+interface ImageState {
+  isCached: boolean;
+  src: string;
+}
+
+// named Img here to avoid conflict with the HTMLImageElement in useEffect
+const Img = ({ className, objectFit = 'cover', alt, src, onLoad, onError }: ImageProps) => {
+  const [image, setImage] = React.useState<ImageState | undefined>();
+
+  useEffect(() => {
+    setImage(undefined);
+    if (src && Boolean(new URL(src))) {
+      const image = new Image();
+      image.src = src;
+      // if image is cached, set isCached so we can skip animations
+      if (image.complete) {
+        setImage({ isCached: true, src });
+      } else {
+        // else wait until load is complete to set state
+        image.onload = () => {
+          setImage({ isCached: false, src });
+        };
+      }
+    }
+  }, [src]);
+
+  return (
+    <div
+      className={classNames(styles.Container, className)}
+      data-status={image?.src ? 'loaded' : 'loading'}
+      data-is-cached={image?.isCached ? '' : undefined}
+    >
+      <img
+        data-testid={'zui-image-img'}
+        className={styles.Image}
+        style={{ objectFit }}
+        src={image?.src}
+        alt={alt}
+        onLoad={onLoad}
+        onError={onError}
+      />
+      <Skeleton className={styles.Skeleton} width={'100%'} height={'100%'} />
+    </div>
+  );
+};
+
+export { Img as Image };

--- a/src/components/Image/index.ts
+++ b/src/components/Image/index.ts
@@ -1,0 +1,1 @@
+export * from './Image';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './AsyncTable';
 export { Button } from './Button';
 export * from './Card';
 export * from './DropdownMenu';
+export * from './Image';
 export { Input } from './Input';
 export { LoadingIndicator } from './LoadingIndicator';
 export * from './Markdown';


### PR DESCRIPTION
Adds a component for smooth Image loading. Shows a `Skeleton` until loading is finished, then fades the loaded image in. If image is loading from browser cache, skip the fade in.