### PR TITLE
fix: remove loading header placeholders

### DIFF
--- a/src/components/AsyncTable/Placeholder.tsx
+++ b/src/components/AsyncTable/Placeholder.tsx
@@ -1,20 +1,6 @@
-import { TableData, TableHeader } from './Column';
+import { TableData } from './Column';
 import Skeleton from 'react-loading-skeleton';
 import React from 'react';
-
-interface HeaderPlaceholdersProps {
-  amount: number;
-}
-
-export const HeaderPlaceholders = ({ amount }: HeaderPlaceholdersProps) => {
-  const columnPlaceholder = (
-    <TableHeader alignment={'center'}>
-      <Skeleton width={'100%'} />
-    </TableHeader>
-  );
-
-  return <>{Array(amount).fill(columnPlaceholder)}</>;
-};
 
 interface RowPlaceholdersProps {
   amount: number;

--- a/src/components/AsyncTable/Table.tsx
+++ b/src/components/AsyncTable/Table.tsx
@@ -1,7 +1,7 @@
 import React, { memo, ReactNode } from 'react';
 
 import { Column, TableHeader } from './Column';
-import { HeaderPlaceholders, RowPlaceholders } from './Placeholder';
+import { RowPlaceholders } from './Placeholder';
 
 import styles from './AsyncTable.module.scss';
 
@@ -15,15 +15,11 @@ export const Table = memo(({ columns, rows, isLoading }: TableProps) => (
   <table className={styles.Table}>
     <thead>
       <tr>
-        {isLoading ? (
-          <HeaderPlaceholders amount={columns.length} />
-        ) : (
-          columns.map((c: Column) => (
-            <TableHeader alignment={c.alignment} key={c.id}>
-              {c.header}
-            </TableHeader>
-          ))
-        )}
+        {columns.map((c: Column) => (
+          <TableHeader alignment={c.alignment} key={c.id}>
+            {c.header}
+          </TableHeader>
+        ))}
       </tr>
     </thead>
     <tbody>{isLoading ? <RowPlaceholders amount={5} height={40} numColumns={columns.length} /> : rows}</tbody>


### PR DESCRIPTION
[Notion Task](https://www.notion.so/zerotech/4985d8ec0c2f4eb4860678eec483e6f6?v=40a33a299f3541f18ec40fbf914ba46f&p=39a32e9780e448ac9b9a7ddffdb2f976&pm=s)

Task: Static table headers should not show a skeleton when table is loading