### PR TITLE
feat: dropdown categories

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.scss
+++ b/src/components/DropdownMenu/DropdownMenu.scss
@@ -2,7 +2,7 @@
 
 .zui-dropdown-trigger {
   background: none;
-  color: #{$text-primary};
+  color: $text-primary;
   border: none;
   cursor: pointer;
   font-size: inherit;
@@ -12,29 +12,55 @@
   width: 16rem; // 256px
   padding: 0.5rem;
 
-  background: #{$purple-10};
+  background: $purple-10;
   display: flex;
   flex-direction: column;
   border-radius: 1rem;
-  border: 1px solid #{$purple-25};
+  border: 1px solid $purple-25;
 
   transform-origin: var(--radix-dropdown-menu-content-transform-origin);
 
   .zui-dropdown-item {
     padding: 1rem;
-
-    color: #{$text-primary};
+    
+    color: $text-primary;
     outline: none;
-
-    &:hover {
+    
+    &:hover, &:focus {
       background: #381C4E;
       text-shadow: 0 0 0.25rem rgba(177, 78, 255, 0.75);
     }
-
+    
     border-radius: 0.5rem;
-
+    
     user-select: none;
     cursor: pointer;
+    
+    &:last-child {
+      border-bottom: 1px solid $purple-25;
+      border-radius: 0;
+      margin-bottom: 1.5rem;
+    }
+  }
+  
+  .zui-dropdown-item-category {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 0 1rem;
+    margin-bottom: 0.5rem;
+    color: $grey-11;
+    user-select: none;
 
+    &:hover, &:focus {
+      outline: none;
+    }
+  }
+
+  .zui-dropdown-separator {
+    height: 1px;
+    background-color: $purple-6;
+    margin-bottom: 1rem;
+    margin-top: 0.25rem;
   }
 }

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -16,41 +16,45 @@ const Template: ComponentStory<typeof DropdownMenu> = args => {
         {...args}
         items={[
           {
+            type: 'category',
             id: 'dropdown_menu_category_1',
-            label: 'Fruit',
+            name: 'Fruit',
             onSelect: () => console.log('you clicked Fruit!'),
-            isCategory: true
+            items: [
+              {
+                id: 'dropdown_menu_1',
+                label: 'Apple',
+                onSelect: () => console.log('you clicked Apple!')
+              },
+              {
+                id: 'dropdown_menu_2',
+                label: 'Pear',
+                onSelect: () => console.log('you clicked Apple!')
+              }
+            ]
           },
           {
             id: 'dropdown_menu_1',
             label: 'Apple',
             onSelect: () => console.log('you clicked Apple!')
-          },
-          {
-            id: 'dropdown_menu_2',
-            label: 'Orange',
-            onSelect: () => console.log('you clicked Orange!')
-          },
-          {
-            id: 'pear',
-            label: 'Pear',
-            onSelect: () => console.log('you clicked Pear!')
           },
           {
             id: 'dropdown_menu_category_2',
-            label: 'More Fruit',
+            type: 'category',
+            name: 'More Fruit',
             onSelect: () => console.log('you clicked More Fruit!'),
-            isCategory: true
-          },
-          {
-            id: 'dropdown_menu_1',
-            label: 'Apple',
-            onSelect: () => console.log('you clicked Apple!')
-          },
-          {
-            id: 'dropdown_menu_2',
-            label: 'Orange',
-            onSelect: () => console.log('you clicked Orange!')
+            items: [
+              {
+                id: 'dropdown_menu_1',
+                label: 'Apple',
+                onSelect: () => console.log('you clicked Apple!')
+              },
+              {
+                id: 'dropdown_menu_2',
+                label: 'Pear',
+                onSelect: () => console.log('you clicked Apple!')
+              }
+            ]
           }
         ]}
       />

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -16,6 +16,12 @@ const Template: ComponentStory<typeof DropdownMenu> = args => {
         {...args}
         items={[
           {
+            id: 'dropdown_menu_category_1',
+            label: 'Fruit',
+            onSelect: () => console.log('you clicked Fruit!'),
+            isCategory: true
+          },
+          {
             id: 'dropdown_menu_1',
             label: 'Apple',
             onSelect: () => console.log('you clicked Apple!')
@@ -29,6 +35,22 @@ const Template: ComponentStory<typeof DropdownMenu> = args => {
             id: 'pear',
             label: 'Pear',
             onSelect: () => console.log('you clicked Pear!')
+          },
+          {
+            id: 'dropdown_menu_category_2',
+            label: 'More Fruit',
+            onSelect: () => console.log('you clicked More Fruit!'),
+            isCategory: true
+          },
+          {
+            id: 'dropdown_menu_1',
+            label: 'Apple',
+            onSelect: () => console.log('you clicked Apple!')
+          },
+          {
+            id: 'dropdown_menu_2',
+            label: 'Orange',
+            onSelect: () => console.log('you clicked Orange!')
           }
         ]}
       />

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -6,7 +6,8 @@ import {
   Root as RadixUIDropdownMenuRoot,
   Trigger as RadixUIDropdownMenuTrigger,
   Content as RadixUIDropdownMenuContent,
-  Item as RadixUIDropdownMenuItem
+  Item as RadixUIDropdownMenuItem,
+  Separator as RadixUIDropdownMenuSeparator
 } from '@radix-ui/react-dropdown-menu';
 
 import './DropdownMenu.scss';
@@ -21,6 +22,7 @@ export interface DropdownItem {
   /** Callback to run when an item is selected */
   onSelect: (event?: Event) => void;
   className?: string;
+  isCategory?: boolean;
 }
 
 export interface DropdownMenuProps {
@@ -73,15 +75,28 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
           side={side}
           ref={ref}
         >
-          {items.map(item => (
-            <RadixUIDropdownMenuItem
-              className={classNames('zui-dropdown-item', item.className)}
-              key={item.id}
-              onSelect={(event: Event) => item.onSelect(event)}
-            >
-              {item.label}
-            </RadixUIDropdownMenuItem>
-          ))}
+          {items.map(item =>
+            item.isCategory ? (
+              <>
+                <RadixUIDropdownMenuSeparator className="zui-dropdown-separator" />
+                <RadixUIDropdownMenuItem
+                  className={classNames('zui-dropdown-item-category', item.className)}
+                  key={item.id}
+                  onSelect={(event: Event) => item.onSelect(event)}
+                >
+                  {item.label}
+                </RadixUIDropdownMenuItem>
+              </>
+            ) : (
+              <RadixUIDropdownMenuItem
+                className={classNames('zui-dropdown-item', item.className)}
+                key={item.id}
+                onSelect={(event: Event) => item.onSelect(event)}
+              >
+                {item.label}
+              </RadixUIDropdownMenuItem>
+            )
+          )}
         </RadixUIDropdownMenuContent>
       </RadixUIDropdownMenuRoot>
     );

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -15,6 +15,7 @@ import './DropdownMenu.scss';
 import classNames from 'classnames';
 
 export interface DropdownItem {
+  type?: 'item';
   /** Unique ID to use in Array.map() */
   id: string;
   /** Label to appear in the menu */
@@ -22,12 +23,22 @@ export interface DropdownItem {
   /** Callback to run when an item is selected */
   onSelect: (event?: Event) => void;
   className?: string;
-  isCategory?: boolean;
+}
+export interface DropdownItemCategory {
+  type: 'category';
+  /** Unique ID to use in Array.map() */
+  id: string;
+  /** Label to appear in the menu */
+  name: string | ReactNode;
+  /** Callback to run when an item is selected */
+  onSelect: (event?: Event) => void;
+  className?: string;
+  items: DropdownItem[];
 }
 
 export interface DropdownMenuProps {
   /** List of items to render in the dropdown menu */
-  items: DropdownItem[];
+  items: Array<DropdownItem | DropdownItemCategory>;
   /** Clicking this will make the dropdown menu appear */
   trigger?: ReactNode;
 
@@ -76,7 +87,8 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
           ref={ref}
         >
           {items.map(item =>
-            item.isCategory ? (
+            // console.log(item.hasOwnProperty('name'))
+            item.type == 'category' ? (
               <>
                 <RadixUIDropdownMenuSeparator className="zui-dropdown-separator" />
                 <RadixUIDropdownMenuItem
@@ -84,8 +96,17 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
                   key={item.id}
                   onSelect={(event: Event) => item.onSelect(event)}
                 >
-                  {item.label}
+                  {item.name}
                 </RadixUIDropdownMenuItem>
+                {item.items.map(item => (
+                  <RadixUIDropdownMenuItem
+                    className={classNames('zui-dropdown-item', item.className)}
+                    key={item.id}
+                    onSelect={(event: Event) => item.onSelect(event)}
+                  >
+                    {item.label}
+                  </RadixUIDropdownMenuItem>
+                ))}
               </>
             ) : (
               <RadixUIDropdownMenuItem


### PR DESCRIPTION
## 1. Pull request checklist
- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card

## 2. What is the old behaviour? (if applicable)
Previously dropdowns did not have categories for items


## 3. What is the new behaviour?
Each dropdown item may now be sorted into categories

## 4. How can this behaviour be tested? (if applicable)
Creating a dropdown item that is a category then putting dropdown items underneath it. 

## 5. Other information
<img width="269" alt="Screenshot 2023-03-06 at 3 11 23 PM" src="https://user-images.githubusercontent.com/74855211/223003826-cf53253b-03ce-4205-97eb-eb54e88a234f.png">
https://www.loom.com/share/9d8638af3a53464abb8417cdc598a6db 