### PR TITLE
fix(grid-card): flicker on image load

### DIFF
--- a/src/components/GridCard/GridCard.module.scss
+++ b/src/components/GridCard/GridCard.module.scss
@@ -11,7 +11,7 @@
         }
     }
 
-    .ImageContainer {
+    .Aspect {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -26,7 +26,6 @@
             object-fit: cover;
 
             transition: transform 0.3s ease;
-
         }
     }
 

--- a/src/components/GridCard/GridCard.tsx
+++ b/src/components/GridCard/GridCard.tsx
@@ -20,11 +20,7 @@ export const GridCard = ({ aspectRatio = 1, className, children, imageAlt, image
   return (
     <div onClick={onClick} className={classNames(styles.Container, className)}>
       <AspectRatioRoot ratio={aspectRatio} className={styles.ImageContainer}>
-        {imageSrc ? (
-          <Image className={styles.Image} src={imageSrc} alt={imageAlt} />
-        ) : (
-          <Skeleton width={'100%'} height={'100%'} />
-        )}
+        <Image className={styles.Image} src={imageSrc} alt={imageAlt} />
       </AspectRatioRoot>
       <div className={styles.Content}>{children}</div>
     </div>

--- a/src/components/GridCard/GridCard.tsx
+++ b/src/components/GridCard/GridCard.tsx
@@ -1,7 +1,6 @@
-import React, { MouseEventHandler, ReactNode } from 'react';
+import React, { forwardRef, MouseEventHandler, ReactNode } from 'react';
 
 import { AspectRatioProps, Root as AspectRatioRoot } from '@radix-ui/react-aspect-ratio';
-import { Skeleton } from '../Skeleton';
 import { Image } from '../Image';
 
 import classNames from 'classnames';
@@ -16,13 +15,15 @@ export interface GridCardProps {
   onClick?: MouseEventHandler<HTMLDivElement>;
 }
 
-export const GridCard = ({ aspectRatio = 1, className, children, imageAlt, imageSrc, onClick }: GridCardProps) => {
-  return (
-    <div onClick={onClick} className={classNames(styles.Container, className)}>
-      <AspectRatioRoot ratio={aspectRatio} className={styles.ImageContainer}>
-        <Image className={styles.Image} src={imageSrc} alt={imageAlt} />
-      </AspectRatioRoot>
-      <div className={styles.Content}>{children}</div>
-    </div>
-  );
-};
+export const GridCard = forwardRef<HTMLDivElement, GridCardProps>(
+  ({ aspectRatio = 1, className, children, imageAlt, imageSrc, onClick }: GridCardProps, ref) => {
+    return (
+      <div onClick={onClick} className={classNames(styles.Container, className)} ref={ref}>
+        <AspectRatioRoot ratio={aspectRatio} className={styles.Aspect}>
+          <Image className={styles.Image} src={imageSrc} alt={imageAlt} />
+        </AspectRatioRoot>
+        <div className={styles.Content}>{children}</div>
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)
<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->

`GridCard` images would flicker while loading

https://user-images.githubusercontent.com/12437916/224830400-ac4f9518-9acf-42aa-b0e0-0801ea019dc6.mov

`GridCard` was showing a `Skeleton` when `imageSrc` was `undefined`. It would render a `Skeleton`, then would flick to `Image`, which also renders a `Skeleton` until `imageSrc` has loaded. This means it would render one `Skeleton`, then change to another `Skeleton`, before ultimately showing the image.

## 3. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

`GridCard` images don't flicker while loading.

I basically just removed the `Skeleton`, and let `Image` handle `undefined` since it was built for that purpose. 

https://user-images.githubusercontent.com/12437916/224830628-987a58cb-0641-438b-afb2-9186e54d7f95.mov

## 4. How can this behaviour be tested? (if applicable)

1. Link to NFTs
2. Navigate the subdomain table on grid view

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->

I also did a tiny amount of refactoring while I was at it
- Changed a class name to be a little more descriptive
- Changed `GridCard` to use `forwardRef`