### PR TITLE
fix: prevent password input from submitting forms

### DIFF
--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -21,7 +21,7 @@ export const PasswordInput = (props: PasswordInputProps) => {
 
 export const EyeButton = (props: { onClick: () => void }) => {
   return (
-    <button onClick={props.onClick} className={styles.PasswordButton}>
+    <button onClick={props.onClick} className={styles.PasswordButton} type="button">
       <IconEye />
     </button>
   );


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->

Previously if you embedded the PasswordInput into a form then clicking the 'eye' toggle would submit the form.

## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->

Clicking the 'eye' toggle no longer submits the form and just toggles the password viewability.

## 4. How can this behaviour be tested? (if applicable)

Embed this input in a form and click the eye. Note the form does not submit.

## 5. Other information

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
