### PR TITLE
feat: Allow buttons to be typed as "submit"

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -85,3 +85,15 @@ test('should apply variant class', () => {
   const button = getByRole('button');
   expect(button).toHaveClass('zui-button-secondary');
 });
+
+test('should default to type "button"', () => {
+  const { getByRole } = renderComponent({ isSubmit: false });
+  const button = getByRole('button');
+  expect(button).toHaveAttribute('type', 'button');
+});
+
+test('should be type "submit" when isSubmit is true', () => {
+  const { getByRole } = renderComponent({ isSubmit: true });
+  const button = getByRole('button');
+  expect(button).toHaveAttribute('type', 'submit');
+});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,6 +17,7 @@ export interface ButtonProps {
   variant?: 'primary' | 'secondary' | 'negative' | 'text';
   isLoading?: boolean;
   isDisabled?: boolean;
+  isSubmit?: boolean;
 }
 
 export const Button: FC<ButtonProps> = ({
@@ -24,6 +25,7 @@ export const Button: FC<ButtonProps> = ({
   className,
   isLoading,
   isDisabled,
+  isSubmit,
   variant = 'primary',
   ...rest
 }) => {
@@ -33,6 +35,7 @@ export const Button: FC<ButtonProps> = ({
   const { buttonProps, isPressed } = useButton(
     {
       ...rest,
+      type: isSubmit ? 'submit' : 'button',
       onPress: rest.onPress
         ? () => {
             if (!disabled) rest.onPress();


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->
Previously all buttons were rendered with `type='button'`.

## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->
This allows specifying a button to be `type='submit'` so that it can be used in a form as a submit action.

## 4. How can this behaviour be tested? (if applicable)

Render in a form and verify that hitting enter in an input on the form fires the onSubmit of the form.

## 5. Other information

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
