### PR TITLE
fix: size the alert with border-box

### DIFF
--- a/src/components/Alert/Alert.module.scss
+++ b/src/components/Alert/Alert.module.scss
@@ -5,6 +5,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem;
+  box-sizing: border-box;
   width: 100%;
 
   border-radius: 0.5rem;


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->
Due to the `width: 100%` and the padding alerts would overflow the box they were contained in:


## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->
With `border-box` `100%` includes all the extra stuff so it gets sized correctly to the container:

## 4. How can this behaviour be tested? (if applicable)

## 5. Other information

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
