### PR TITLE
chore: bump version (`0.20.0`) -> (`0.20.1`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero-tech/zui",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Zero UI React Component Library",
   "scripts": {
     "about:clean": "echo 'Removes any existing build folders.'",


### PR DESCRIPTION
- chore: bump version (`0.20.0`) -> (`0.20.1`) 
- to publish table header alignments