### PR TITLE
fix: Use the disabled attribute for Button rather than our own handling

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -36,11 +36,7 @@ export const Button: FC<ButtonProps> = ({
     {
       ...rest,
       type: isSubmit ? 'submit' : 'button',
-      onPress: rest.onPress
-        ? () => {
-            if (!disabled) rest.onPress();
-          }
-        : undefined
+      isDisabled: disabled
     },
     ref ?? null
   );


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->

Previously the button itself wasn't actually disabled (i.e., the `disabled` attribute wasn't set on the rendered node). We were manually preventing onPress events by checking the disabled flag. But, this means that buttons inside forms would still submit the form when hitting enter.

## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->

We now set the `disabled` attribute on the `button` node so.

## 4. How can this behaviour be tested? (if applicable)

Render the button with `isDisabled={true}` and verify that the HTML node has `disabled` set.

## 5. Other information

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
