### PR TITLE
fix: video container styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero-tech/zui",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Zero UI React Component Library",
   "scripts": {
     "about:clean": "echo 'Removes any existing build folders.'",

--- a/src/components/Video/Video.module.scss
+++ b/src/components/Video/Video.module.scss
@@ -1,31 +1,31 @@
 .VideoContainer {
-  position: relative;
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
-  video {
-    width: 100%;
+  .Controls {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5rem;
+    border-radius: 0 0 0.5rem 0.5rem;
+    background-color: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 1));
+    transition: opacity 0.5s;
+    opacity: 0;
   }
 
-  .VideoControls {
-    position: absolute;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 40px;
+  &:hover .Controls {
+    opacity: 1;
+  }
 
-    .Control {
-      background: none;
-      border: none;
-      padding: 0;
-      margin: 0 5px;
-      cursor: pointer;
+  .Control {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0 5px;
+    cursor: pointer;
 
-      &:hover {
-        opacity: 0.7;
-      }
+    &:hover {
+      opacity: 0.7;
     }
   }
 }

--- a/src/components/Video/Video.test.tsx
+++ b/src/components/Video/Video.test.tsx
@@ -33,17 +33,18 @@ describe('<Video />', () => {
     expect(mockPlay).toHaveBeenCalled();
   });
 
+  test('should be muted by default and unmute when clicked', () => {
+    const video = render(<Video {...DEFAULT_PROPS} />).container.querySelector('video');
+    expect(video?.muted).toBe(true);
+    fireEvent.click(screen.getByTestId('mute-button'));
+    expect(video?.muted).toBe(false);
+  });
+
   test('should mute video when mute button is clicked', () => {
     const video = render(<Video {...DEFAULT_PROPS} />).container.querySelector('video');
     fireEvent.click(screen.getByTestId('mute-button'));
+    fireEvent.click(screen.getByTestId('mute-button'));
     expect(video?.muted).toBe(true);
-  });
-
-  test('should unmute video when unmute button is clicked', () => {
-    const video = render(<Video {...DEFAULT_PROPS} />).container.querySelector('video');
-    fireEvent.click(screen.getByTestId('mute-button'));
-    fireEvent.click(screen.getByTestId('mute-button'));
-    expect(video?.muted).toBe(false);
   });
 
   test('should call onError when video encounters an error', () => {

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -2,9 +2,11 @@ import React, { FC, useRef, useState } from 'react';
 
 import { IconGrid, IconPlay, IconVolumeMax, IconVolumeX } from '../Icons';
 
+import classNames from 'classnames';
 import styles from './Video.module.scss';
 
 export interface VideoProps {
+  className?: string;
   src: string;
   poster?: string;
   autoPlay?: boolean;
@@ -12,7 +14,7 @@ export interface VideoProps {
   onError?: () => void;
 }
 
-export const Video: FC<VideoProps> = ({ src, poster, autoPlay, loop, onError }) => {
+export const Video: FC<VideoProps> = ({ className, src, poster, autoPlay, loop, onError }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const [isMuted, setIsMuted] = useState(false);
@@ -40,7 +42,7 @@ export const Video: FC<VideoProps> = ({ src, poster, autoPlay, loop, onError }) 
   };
 
   return (
-    <div className={styles.VideoContainer}>
+    <div className={classNames(styles.VideoContainer, className)}>
       <video
         data-testid="video-element"
         ref={videoRef}
@@ -51,7 +53,7 @@ export const Video: FC<VideoProps> = ({ src, poster, autoPlay, loop, onError }) 
         loop={loop}
       />
 
-      <div className={styles.VideoControls}>
+      <div className={styles.Controls}>
         <button data-testid="play-button" className={styles.Control} onClick={togglePlayPause}>
           {isPlaying ? (
             <IconGrid isFilled color="#ffffff" size={16} />

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -14,7 +14,7 @@ export interface VideoProps {
   onError?: () => void;
 }
 
-export const Video: FC<VideoProps> = ({ className, src, poster, autoPlay, loop, onError }) => {
+export const Video = ({ className, src, poster, autoPlay, loop, onError }: VideoProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const [isMuted, setIsMuted] = useState(false);

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { IconGrid, IconPlay, IconVolumeMax, IconVolumeX } from '../Icons';
 
@@ -17,7 +17,7 @@ export interface VideoProps {
 export const Video = ({ className, src, poster, autoPlay, loop, onError }: VideoProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  const [isMuted, setIsMuted] = useState(false);
+  const [isMuted, setIsMuted] = useState(true);
   const [isPlaying, setIsPlaying] = useState(autoPlay);
 
   const togglePlayPause = () => {
@@ -33,13 +33,34 @@ export const Video = ({ className, src, poster, autoPlay, loop, onError }: Video
     }
   };
 
-  const toggleMute = () => {
+  const toggleMute = (event: React.MouseEvent<HTMLButtonElement>) => {
     const video = videoRef.current;
     if (video) {
       video.muted = !video.muted;
       setIsMuted(video.muted);
+      event.preventDefault();
     }
   };
+
+  useEffect(() => {
+    const video = videoRef.current;
+
+    const handleContainerClick = () => {
+      if (isPlaying) {
+        video?.pause();
+        setIsPlaying(false);
+      } else {
+        video?.play();
+        setIsPlaying(true);
+      }
+    };
+
+    video?.addEventListener('click', handleContainerClick);
+
+    return () => {
+      video?.removeEventListener('click', handleContainerClick);
+    };
+  }, [isPlaying]);
 
   return (
     <div className={classNames(styles.VideoContainer, className)}>
@@ -51,6 +72,7 @@ export const Video = ({ className, src, poster, autoPlay, loop, onError }: Video
         onError={onError}
         autoPlay={autoPlay}
         loop={loop}
+        muted={isMuted}
       />
 
       <div className={styles.Controls}>
@@ -62,7 +84,7 @@ export const Video = ({ className, src, poster, autoPlay, loop, onError }: Video
           )}
         </button>
 
-        <button data-testid="mute-button" className={styles.Control} onClick={toggleMute}>
+        <button data-testid="mute-button" className={styles.Control} type="button" onClick={toggleMute}>
           {isMuted ? (
             <IconVolumeX isFilled color="#ffffff" size={16} />
           ) : (

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,4 +31,5 @@ export * from './TextStack';
 export { ThemeEngine } from './ThemeEngine';
 export * from './ToggleGroup';
 export * from './Tooltip';
+export * from './Video';
 export { Wizard } from './Wizard';


### PR DESCRIPTION
Container styles are causing breaks on parent components in zApps.
- fix container styles and pass classNames
- bump zUI version (`0.21.0`) -> (`0.21.1`)

Breaks caused:
<img width="1378" alt="Screenshot 2023-05-10 at 14 01 12" src="https://github.com/zer0-os/zUI/assets/39112648/a1bbd117-bf3d-4c42-b35d-9ba5cb0b273e">

Some additions: (This isn't the final color)

https://github.com/zer0-os/zUI/assets/39112648/18fd5956-6bc4-48d7-b90b-8693d576370e

