### PR TITLE
feat: add toast notification component

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@radix-ui/react-dropdown-menu": "^0.1.6",
     "@radix-ui/react-slider": "^1.1.0",
     "@radix-ui/react-tabs": "^0.1.5",
+    "@radix-ui/react-toast": "^1.1.3",
     "@radix-ui/react-toggle": "^1.0.0",
     "@radix-ui/react-toggle-group": "^1.0.0",
     "@radix-ui/react-tooltip": "^1.0.0",

--- a/src/components/ToastNotification/ToastNotification.module.scss
+++ b/src/components/ToastNotification/ToastNotification.module.scss
@@ -1,0 +1,227 @@
+@import '../../styles/theme';
+
+/* reset */
+button {
+  all: unset;
+}
+
+.ToastRoot {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border-radius: 0.5rem;
+  padding: 1.5rem 0.5rem 1.5rem 1.5rem;
+  gap: 1.5rem;
+
+  .TextWrapper {
+    display: flex;
+    flex-direction: column;
+    max-width: 14.5rem;
+
+    .ToastTitle {
+      font-weight: 700;
+      font-size: 1rem;
+      line-height: 1.5rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ToastDescription {
+      font-size: 0.75rem;
+      line-height: 0.908rem;
+      color: $color-greyscale-12;
+    }
+  }
+
+  .ToastClose {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 2.25rem;
+    width: 2.25rem;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  // primary variants
+  &[data-variant='primary'] {
+    background: $color-primary-2;
+    border: 1px solid $color-primary-6;
+
+    .ToastIcon {
+      color: $color-primary-11;
+    }
+
+    .ToastTitle {
+      color: $color-greyscale-12;
+    }
+
+    .ToastClose {
+      border-left: 1px solid $color-primary-6;
+    }
+  }
+
+  // success variants
+  &[data-variant='success'] {
+    background: $color-success-3;
+    border: 1px solid $color-success-6;
+
+    .ToastIcon {
+      color: $color-success-11;
+    }
+
+    .ToastTitle {
+      color: $color-success-11;
+    }
+
+    .ToastClose {
+      border-left: 1px solid $color-success-6;
+    }
+  }
+
+  // error variants
+  &[data-variant='error'] {
+    background: $color-failure-3;
+    border: 1px solid $color-failure-6;
+
+    .ToastIcon {
+      color: $color-failure-11;
+    }
+
+    .ToastTitle {
+      color: $color-failure-11;
+    }
+
+    .ToastClose {
+      border-left: 1px solid $color-failure-6;
+    }
+
+    .ToastButton {
+      &:first-of-type {
+        div {
+          color: $color-failure-11;
+        }
+      }
+    }
+  }
+
+  // left position
+  &[data-position='left'] {
+    &[data-state='open'] {
+      animation: slideInLeft 200ms cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    &[data-state='closed'] {
+      animation: hideLeft 100ms ease-in;
+    }
+
+    &[data-swipe='end'] {
+      animation: swipeOutLeft 100ms ease-out;
+    }
+  }
+
+  // right position
+  &[data-position='right'] {
+    &[data-state='open'] {
+      animation: slideInRight 200ms cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    &[data-state='closed'] {
+      animation: hideRight 100ms ease-in;
+    }
+
+    &[data-swipe='end'] {
+      animation: swipeOutRight 100ms ease-out;
+    }
+  }
+
+  &[data-swipe='move'] {
+    transform: translateX(var(--radix-toast-swipe-move-x));
+  }
+
+  &[data-swipe='cancel'] {
+    transform: translateX(0);
+    transition: transform 100ms ease-out;
+  }
+}
+
+.ToastViewport {
+  --viewport-padding: 1.5rem;
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  max-width: 100vw;
+  list-style: none;
+  margin: 0;
+  bottom: 0;
+  right: 0;
+  padding: var(--viewport-padding);
+  gap: 0.625rem;
+  z-index: 99999;
+  outline: none;
+
+  &[data-variant='left'] {
+    right: unset;
+    left: 0;
+  }
+}
+
+// left and right positioning animations
+@keyframes hideRight {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: translateX(calc(100% - var(--viewport-padding)));
+  }
+}
+
+@keyframes slideInRight {
+  from {
+    transform: translateX(calc(100% + var(--viewport-padding)));
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes swipeOutRight {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+  to {
+    transform: translateX(calc(100% + var(--viewport-padding)));
+  }
+}
+
+@keyframes hideLeft {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: translateX(calc(-100% - var(--viewport-padding)));
+  }
+}
+
+@keyframes slideInLeft {
+  from {
+    transform: translateX(calc(-100% - var(--viewport-padding)));
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes swipeOutLeft {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+  to {
+    transform: translateX(calc(-100% - var(--viewport-padding)));
+  }
+}

--- a/src/components/ToastNotification/ToastNotification.stories.tsx
+++ b/src/components/ToastNotification/ToastNotification.stories.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ToastNotification } from './ToastNotification';
+import { Modal } from '../Modal';
+
+export default {
+  title: 'Data Display/Toast Notification',
+  component: ToastNotification
+} as ComponentMeta<typeof ToastNotification>;
+
+const Template: ComponentStory<typeof ToastNotification> = args => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [openToast, setOpenToast] = useState(false);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setTimeout(() => setOpenToast(true), 2000);
+  };
+
+  const handleToastClose = () => {
+    setOpenToast(false);
+  };
+
+  return (
+    <React.Fragment>
+      <Modal trigger="Open Modal" open={isOpen} onOpenChange={setIsOpen}>
+        <p>This is a modal. Close this modal to see a toast notification after 2 seconds.</p>
+        <button onClick={handleClose}>Close Modal</button>
+      </Modal>
+
+      <ToastNotification {...args} openToast={openToast} onClick={handleToastClose} onClose={handleToastClose} />
+    </React.Fragment>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'Toast Notification Title',
+  description: 'Toast Notification Description',
+  actionTitle: 'Invite',
+  swipeDirection: 'left'
+};

--- a/src/components/ToastNotification/ToastNotification.test.tsx
+++ b/src/components/ToastNotification/ToastNotification.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { ToastNotification, ToastNotificationProps } from './';
+
+const mockOnClick = jest.fn();
+const mockOnClose = jest.fn();
+
+const DEFAULT_PROPS: ToastNotificationProps = {
+  title: 'Toast Notification Title',
+  description: 'Toast Notification Description',
+  actionTitle: 'Invite',
+  actionAltText: 'call to action',
+  positionVariant: 'right',
+  themeVariant: 'primary',
+  swipeDirection: 'left',
+  openToast: true,
+  onClick: mockOnClick,
+  onClose: mockOnClose
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('<ToastNotification />', () => {
+  test('should render without crashing', () => {
+    render(<ToastNotification {...DEFAULT_PROPS} />);
+    expect(screen.getByText(DEFAULT_PROPS.title)).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_PROPS.description)).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_PROPS.actionTitle)).toBeInTheDocument();
+  });
+
+  test('should render the ToastNotification with title and description', () => {
+    render(<ToastNotification {...DEFAULT_PROPS} />);
+    expect(screen.getByText(DEFAULT_PROPS.title)).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_PROPS.description)).toBeInTheDocument();
+  });
+
+  test('should call onClick when action button is clicked', () => {
+    render(<ToastNotification {...DEFAULT_PROPS} />);
+    fireEvent.click(screen.getByText(DEFAULT_PROPS.actionTitle));
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  test('should call onClose when close button is clicked', () => {
+    render(<ToastNotification {...DEFAULT_PROPS} />);
+    fireEvent.click(screen.getByTestId('toast-close-button'));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  test('should close the toast automatically after 10 seconds', async () => {
+    jest.useFakeTimers();
+    render(<ToastNotification {...DEFAULT_PROPS} />);
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+    await waitFor(() => expect(screen.queryByText(DEFAULT_PROPS.title)).not.toBeInTheDocument());
+  });
+
+  test('should not render the toast when openToast is false', () => {
+    render(<ToastNotification {...DEFAULT_PROPS} openToast={false} />);
+    expect(screen.queryByText(DEFAULT_PROPS.title)).not.toBeInTheDocument();
+  });
+
+  test('should render the toast when openToast changes from false to true', () => {
+    const { rerender } = render(<ToastNotification {...DEFAULT_PROPS} openToast={false} />);
+    expect(screen.queryByText(DEFAULT_PROPS.title)).not.toBeInTheDocument();
+
+    rerender(<ToastNotification {...DEFAULT_PROPS} openToast={true} />);
+    expect(screen.getByText(DEFAULT_PROPS.title)).toBeInTheDocument();
+  });
+
+  test.each([
+    ['left', 'right'],
+    ['right', 'left']
+  ])('should render with position %s', (positionVariant, notPosition) => {
+    render(<ToastNotification {...DEFAULT_PROPS} positionVariant={positionVariant as 'left' | 'right'} />);
+    const toastRoot = screen.getByTestId('toast-root');
+    expect(toastRoot).toHaveAttribute('data-position', positionVariant);
+    expect(toastRoot).not.toHaveAttribute('data-position', notPosition);
+  });
+
+  test.each([
+    ['primary', ['success', 'error']],
+    ['success', ['primary', 'error']],
+    ['error', ['primary', 'success']]
+  ])('should render with theme %s', (themeVariant, notThemes) => {
+    render(<ToastNotification {...DEFAULT_PROPS} themeVariant={themeVariant as 'primary' | 'success' | 'error'} />);
+    const toastRoot = screen.getByTestId('toast-root');
+    expect(toastRoot).toHaveAttribute('data-variant', themeVariant);
+    notThemes.forEach(notTheme => {
+      expect(toastRoot).not.toHaveAttribute('data-variant', notTheme);
+    });
+  });
+});

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -30,11 +30,11 @@ export const ToastNotification = ({
   title,
   description,
   actionTitle,
-  actionAltText,
-  positionVariant,
-  themeVariant,
-  swipeDirection,
-  openToast,
+  actionAltText = 'call to action',
+  positionVariant = 'right',
+  themeVariant = 'primary',
+  swipeDirection = 'left',
+  openToast = false,
   onClick,
   onClose
 }: ToastNotificationProps) => {
@@ -89,11 +89,4 @@ export const ToastNotification = ({
       <Toast.Viewport className={ToastViewport} data-variant={positionVariant} />
     </Toast.Provider>
   );
-};
-
-ToastNotification.defaultProps = {
-  positionVariant: 'right',
-  themeVariant: 'primary',
-  actionAltText: 'call to action',
-  openToast: false
 };

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -1,0 +1,99 @@
+import React, { FC, useEffect, useState, useRef, useCallback } from 'react';
+
+import { Button } from '../Button';
+import { IconInfoCircle, IconXClose } from '../Icons';
+
+import * as Toast from '@radix-ui/react-toast';
+
+import styles from './ToastNotification.module.scss';
+
+type ToastPositionVariant = 'left' | 'right';
+type ToastThemeVariant = 'primary' | 'success' | 'error';
+
+const { ToastRoot, ToastIcon, TextWrapper, ToastTitle, ToastDescription, ToastButton, ToastClose, ToastViewport } =
+  styles;
+
+export type ToastNotificationProps = Toast.ToastProviderProps & {
+  title: string;
+  description: string;
+  actionTitle: string;
+  actionAltText: string;
+  positionVariant?: ToastPositionVariant;
+  themeVariant?: ToastThemeVariant;
+  swipeDirection?: Toast.SwipeDirection;
+  openToast?: boolean;
+  onClick?: () => void;
+  onClose?: () => void;
+};
+
+export const ToastNotification: FC<ToastNotificationProps> = ({
+  title,
+  description,
+  actionTitle,
+  actionAltText,
+  positionVariant,
+  themeVariant,
+  swipeDirection,
+  openToast,
+  onClick,
+  onClose
+}) => {
+  const timerRef = useRef(0);
+
+  const [open, setOpen] = useState(false);
+
+  const buttonVariant = themeVariant === 'error' ? 'negative' : 'primary';
+
+  const handleOnClose = useCallback(() => {
+    setOpen(false);
+    onClose && onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    setOpen(openToast);
+    if (openToast) {
+      timerRef.current = window.setTimeout(handleOnClose, 10000);
+    }
+
+    return () => clearTimeout(timerRef.current);
+  }, [openToast, handleOnClose]);
+
+  return (
+    <Toast.Provider swipeDirection={swipeDirection}>
+      <Toast.Root
+        data-testid="toast-root"
+        className={ToastRoot}
+        data-variant={themeVariant}
+        data-position={positionVariant}
+        open={open}
+        onOpenChange={handleOnClose}
+      >
+        <div className={ToastIcon}>
+          <IconInfoCircle />
+        </div>
+        <div className={TextWrapper}>
+          <Toast.Title className={ToastTitle}>{title}</Toast.Title>
+          <Toast.Description className={ToastDescription}>{description}</Toast.Description>
+        </div>
+        <Toast.Action onClick={onClick} asChild altText={actionAltText}>
+          <Button className={ToastButton} variant={buttonVariant}>
+            {actionTitle}
+          </Button>
+        </Toast.Action>
+        <Toast.Close className={styles.ToastClose} asChild data-testid="toast-close-button">
+          <button onClick={handleOnClose}>
+            <IconXClose size={24} />
+          </button>
+        </Toast.Close>
+      </Toast.Root>
+      <Toast.Viewport className={ToastViewport} data-variant={positionVariant} />
+    </Toast.Provider>
+  );
+};
+
+ToastNotification.defaultProps = {
+  positionVariant: 'right',
+  themeVariant: 'primary',
+  actionAltText: 'call to action',
+  openToast: false
+};

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 
 import { Button } from '../Button';
 import { IconInfoCircle, IconXClose } from '../Icons';
@@ -26,7 +26,7 @@ export type ToastNotificationProps = Toast.ToastProviderProps & {
   onClose?: () => void;
 };
 
-export const ToastNotification: FC<ToastNotificationProps> = ({
+export const ToastNotification = ({
   title,
   description,
   actionTitle,
@@ -37,7 +37,7 @@ export const ToastNotification: FC<ToastNotificationProps> = ({
   openToast,
   onClick,
   onClose
-}) => {
+}: ToastNotificationProps) => {
   const timerRef = useRef(0);
 
   const [open, setOpen] = useState(false);

--- a/src/components/ToastNotification/index.ts
+++ b/src/components/ToastNotification/index.ts
@@ -1,0 +1,1 @@
+export * from './ToastNotification';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -29,6 +29,7 @@ export * from './Table';
 export * from './Tabs';
 export * from './TextStack';
 export { ThemeEngine } from './ThemeEngine';
+export * from './ToastNotification';
 export * from './ToggleGroup';
 export * from './Tooltip';
 export * from './Video';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,6 +2193,17 @@
     "@radix-ui/react-primitive" "1.0.1"
     "@radix-ui/react-slot" "1.0.1"
 
+"@radix-ui/react-collection@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.2.tgz#d50da00bfa2ac14585319efdbbb081d4c5a29a97"
+  integrity sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.2"
+    "@radix-ui/react-slot" "1.0.1"
+
 "@radix-ui/react-compose-refs@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz#cff6e780a0f73778b976acff2c2a5b6551caab95"
@@ -2273,6 +2284,18 @@
     "@radix-ui/react-primitive" "1.0.0"
     "@radix-ui/react-use-callback-ref" "1.0.0"
     "@radix-ui/react-use-escape-keydown" "1.0.0"
+
+"@radix-ui/react-dismissable-layer@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.3.tgz#63844d8e6bbcd010a513e7176d051c3c4044e09e"
+  integrity sha512-nXZOvFjOuHS1ovumntGV7NNoLaEp9JEvTht3MBjP44NSW5hUKj/8OnfN3+8WmB+CEhN44XaGhpHoSsUIEl5P7Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-escape-keydown" "1.0.2"
 
 "@radix-ui/react-dropdown-menu@^0.1.6":
   version "0.1.6"
@@ -2393,6 +2416,14 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.0"
 
+"@radix-ui/react-portal@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.2.tgz#102370b1027a767a371cab0243be4bc664f72330"
+  integrity sha512-swu32idoCW7KA2VEiUZGBSu9nB6qwGdV6k6HYhUoOo3M1FFpD+VgLzUqtt3mwL1ssz7r2x8MggpLSQach2Xy/Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.2"
+
 "@radix-ui/react-presence@0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-0.1.2.tgz#9f11cce3df73cf65bc348e8b76d891f0d54c1fe3"
@@ -2431,6 +2462,14 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz#c1ebcce283dd2f02e4fbefdaa49d1cb13dbc990a"
   integrity sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-primitive@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz#54e22f49ca59ba88d8143090276d50b93f8a7053"
+  integrity sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.1"
@@ -2520,6 +2559,25 @@
     "@radix-ui/react-primitive" "0.1.4"
     "@radix-ui/react-roving-focus" "0.1.5"
     "@radix-ui/react-use-controllable-state" "0.1.0"
+
+"@radix-ui/react-toast@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toast/-/react-toast-1.1.3.tgz#41098f05bace7976cd4c07f6ff418261f86ede6e"
+  integrity sha512-yHFgpxi9wjbfPvpSPdYAzivCqw48eA1ofT8m/WqYOVTxKPdmQMuVKRYPlMmj4C1d6tJdFj/LBa1J4iY3fL4OwQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-collection" "1.0.2"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.3"
+    "@radix-ui/react-portal" "1.0.2"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+    "@radix-ui/react-visually-hidden" "1.0.2"
 
 "@radix-ui/react-toggle-group@^1.0.0":
   version "1.0.0"
@@ -2625,6 +2683,14 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-callback-ref" "1.0.0"
 
+"@radix-ui/react-use-escape-keydown@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.2.tgz#09ab6455ab240b4f0a61faf06d4e5132c4d639f6"
+  integrity sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
 "@radix-ui/react-use-layout-effect@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz#ebf71bd6d2825de8f1fbb984abf2293823f0f223"
@@ -2684,6 +2750,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.0"
+
+"@radix-ui/react-visually-hidden@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.2.tgz#29b117a59ef09a984bdad12cb98d81e8350be450"
+  integrity sha512-qirnJxtYn73HEk1rXL12/mXnu2rwsNHDID10th2JGtdK25T9wX+mxRmGt7iPSahw512GbZOc0syZX1nLQGoEOg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.2"
 
 "@radix-ui/rect@0.1.1":
   version "0.1.1"


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 3. What is the new behaviour?

- toast notification component with animation.


https://github.com/zer0-os/zUI/assets/39112648/eff8a73f-fb7c-4222-ad15-dcd86fcc67c5



## 4. How can this behaviour be tested? (if applicable)

- use the zUI deployment preview
- I have used the modal component in the toast story to highlight the intended behaviour of the toast (as an example)

