### PR TITLE
chore: bump version (`0.21.3`) -> (`0.22.0`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero-tech/zui",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "description": "Zero UI React Component Library",
   "scripts": {
     "about:clean": "echo 'Removes any existing build folders.'",


### PR DESCRIPTION
- chore: bump version (`0.21.3`) -> (`0.22.0`) (for publishing)