### PR TITLE
fix: `PasswordInput` should not fire `onSubmit` of containing `form` 

### DIFF
--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import { IconButton, IconButtonProperties } from '.';
-import { IconXClose } from '../Icons/icons/IconXClose';
+import { IconXClose } from '../Icons';
 
 let iconRender = jest.fn();
 jest.mock('../Icons/icons/IconXClose', () => {

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -55,6 +55,18 @@ describe('IconButton', () => {
     expect(onClick).toHaveBeenCalledOnce();
   });
 
+  it('passes `type` to button', () => {
+    const { getByRole } = renderComponent({ type: 'submit' });
+
+    expect(getByRole('button')).toHaveAttribute('type', 'submit');
+  });
+
+  it('should default to `button` type', () => {
+    const { getByRole } = renderComponent();
+
+    expect(getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
   it('prevents propagation of click event', () => {
     const onClick = jest.fn();
     const onOuterClick = jest.fn();

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, JSXElementConstructor } from 'react';
+import React, { ButtonHTMLAttributes, FC, JSXElementConstructor, MouseEvent } from 'react';
 
 import classNames from 'classnames';
 import { IconProps } from '../Icons/Icons.types';
@@ -7,7 +7,7 @@ import './IconButton.scss';
 
 export interface IconButtonProperties {
   className?: string;
-  onClick: () => void;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
 
   Icon: JSXElementConstructor<IconProps>;
   label?: string;
@@ -16,6 +16,7 @@ export interface IconButtonProperties {
   variant?: 'primary' | 'secondary' | 'tertiary';
   color?: 'primary' | 'red' | 'greyscale';
   isDisabled?: boolean;
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }
 
 const getSize = (size: IconButtonProperties['size']) => {
@@ -42,11 +43,12 @@ export const IconButton: FC<IconButtonProperties> = ({
   isFilled,
   variant,
   color,
-  isDisabled
+  isDisabled,
+  type = 'button'
 }) => {
-  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+  function handleClick(event: MouseEvent<HTMLButtonElement>) {
     event.stopPropagation();
-    onClick();
+    onClick(event);
   }
 
   return (
@@ -59,6 +61,7 @@ export const IconButton: FC<IconButtonProperties> = ({
       )}
       onClick={handleClick}
       disabled={isDisabled}
+      type={type}
     >
       <Icon label={label} size={getSize(size)} isFilled={isFilled} />
     </button>

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, FC, JSXElementConstructor, MouseEvent } from 'react';
+import React, { ButtonHTMLAttributes, JSXElementConstructor, MouseEvent } from 'react';
 
 import classNames from 'classnames';
 import { IconProps } from '../Icons/Icons.types';

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -34,7 +34,7 @@ const getSize = (size: IconButtonProperties['size']) => {
   return size;
 };
 
-export const IconButton: FC<IconButtonProperties> = ({
+export const IconButton = ({
   Icon,
   onClick,
   className,
@@ -45,7 +45,7 @@ export const IconButton: FC<IconButtonProperties> = ({
   color,
   isDisabled,
   type = 'button'
-}) => {
+}: IconButtonProperties) => {
   function handleClick(event: MouseEvent<HTMLButtonElement>) {
     event.stopPropagation();
     onClick(event);

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,22 +1,21 @@
 import React, { ButtonHTMLAttributes, JSXElementConstructor, MouseEvent } from 'react';
 
-import classNames from 'classnames';
 import { IconProps } from '../Icons/Icons.types';
 
+import classNames from 'classnames';
 import './IconButton.scss';
 
 export interface IconButtonProperties {
-  className?: string;
-  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
-
   Icon: JSXElementConstructor<IconProps>;
-  label?: string;
-  size?: string | number | 'large' | 'small' | 'x-small';
-  isFilled?: boolean;
-  variant?: 'primary' | 'secondary' | 'tertiary';
+  className?: string;
   color?: 'primary' | 'red' | 'greyscale';
   isDisabled?: boolean;
+  isFilled?: boolean;
+  label?: string;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  size?: string | number | 'large' | 'small' | 'x-small';
   type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+  variant?: 'primary' | 'secondary' | 'tertiary';
 }
 
 const getSize = (size: IconButtonProperties['size']) => {
@@ -36,20 +35,20 @@ const getSize = (size: IconButtonProperties['size']) => {
 
 export const IconButton = ({
   Icon,
-  onClick,
   className,
-  label,
-  size,
-  isFilled,
-  variant,
   color,
   isDisabled,
-  type = 'button'
+  isFilled,
+  label,
+  onClick,
+  size,
+  type = 'button',
+  variant
 }: IconButtonProperties) => {
-  function handleClick(event: MouseEvent<HTMLButtonElement>) {
+  const handleOnClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onClick(event);
-  }
+  };
 
   return (
     <button
@@ -59,8 +58,8 @@ export const IconButton = ({
         `zui-iconButton-variant-${variant}`,
         className
       )}
-      onClick={handleClick}
       disabled={isDisabled}
+      onClick={handleOnClick}
       type={type}
     >
       <Icon label={label} size={getSize(size)} isFilled={isFilled} />

--- a/src/components/Input/PasswordInput.test.tsx
+++ b/src/components/Input/PasswordInput.test.tsx
@@ -18,4 +18,10 @@ describe('<PasswordInput />', () => {
     button.click();
     expect(input.type).toBe('password');
   });
+
+  test('should set IconButton `type` to `button`', () => {
+    const { getByRole } = renderComponent({ value: '', onChange: () => null });
+    const button = getByRole('button') as HTMLButtonElement;
+    expect(button.type).toBe('button');
+  });
 });

--- a/src/components/Input/PasswordInput.test.tsx
+++ b/src/components/Input/PasswordInput.test.tsx
@@ -5,15 +5,17 @@ import { PasswordInput, PasswordInputProps } from './PasswordInput';
 
 const renderComponent = (props: PasswordInputProps) => render(<PasswordInput {...props} />);
 
-test('toggles visibility', async () => {
-  const { getByDisplayValue, getByRole } = renderComponent({ value: '', onChange: () => null });
+describe('<PasswordInput />', () => {
+  test('should toggle visibility', async () => {
+    const { getByDisplayValue, getByRole } = renderComponent({ value: '', onChange: () => null });
 
-  const input = getByDisplayValue('') as HTMLInputElement;
-  const button = getByRole('button') as HTMLButtonElement;
+    const input = getByDisplayValue('') as HTMLInputElement;
+    const button = getByRole('button') as HTMLButtonElement;
 
-  expect(input.type).toBe('password');
-  button.click();
-  expect(input.type).toBe('text');
-  button.click();
-  expect(input.type).toBe('password');
+    expect(input.type).toBe('password');
+    button.click();
+    expect(input.type).toBe('text');
+    button.click();
+    expect(input.type).toBe('password');
+  });
 });

--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -18,7 +18,7 @@ export const PasswordInput = (props: PasswordInputProps) => {
     <Input
       {...props}
       type={isHidden ? 'password' : 'text'}
-      endEnhancer={<IconButton onClick={toggleVisiblity} Icon={isHidden ? IconEye : IconEyeOff} />}
+      endEnhancer={<IconButton type={'button'} onClick={toggleVisiblity} Icon={isHidden ? IconEye : IconEyeOff} />}
     />
   );
 };

--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -1,24 +1,23 @@
 import React, { useState } from 'react';
 
-import { Input, InputProps } from './Input';
-import { IconEye, IconEyeOff } from '../../icons';
-
 import { IconButton } from '../IconButton';
+import { Input, InputProps } from './Input';
+import { IconEye, IconEyeOff } from '../Icons';
 
 export type PasswordInputProps = Omit<InputProps, 'type'>;
 
 export const PasswordInput = (props: PasswordInputProps) => {
   const [isHidden, setIsHidden] = useState(true);
 
-  function toggleVisiblity() {
+  const toggleVisiblity = () => {
     setIsHidden(!isHidden);
-  }
+  };
 
   return (
     <Input
-      {...props}
+      endEnhancer={<IconButton Icon={isHidden ? IconEye : IconEyeOff} onClick={toggleVisiblity} type={'button'} />}
       type={isHidden ? 'password' : 'text'}
-      endEnhancer={<IconButton type={'button'} onClick={toggleVisiblity} Icon={isHidden ? IconEye : IconEyeOff} />}
+      {...props}
     />
   );
 };


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->

When using `PasswordInput` inside the `zOS` login form, the show/hide button would be pressed on enter, rather than the `form` submit button. This is because a `button` `type` was not specified for `IconButton`. This also means that any `form` with an `IconButton` inside it wouldn't submit on enter.

## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->

- Added a `button` `type` property to `IconButton`
- Set `type` to `type={'button'}` by default
- Added tests to make sure the `type` stays `button`

## 4. How can this behaviour be tested? (if applicable)

- Add `PasswordInput` to a `form`
- Add a submit `button` to the `form`
- Type a password input, and hit enter

At this point, the `form` `onSubmit` should have been called, rather than the show/hide button `onClick`.

## 5. Other information

Did a tiny amount of refactoring while I had these files open - you'll see it outlined in the commit history.

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
