### PR TITLE
feat: modal background opacity + blur

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -12,8 +12,12 @@
   overflow-y: auto;
   z-index: 10000;
 
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(5px);
+  background: rgba(0, 0, 0, 0.85);
+
+  @supports (backdrop-filter: blur(5px)) {
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(5px);
+  }
 }
 
 .Content {

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -13,6 +13,7 @@
   z-index: 10000;
 
   background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(5px);
 }
 
 .Content {

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -12,7 +12,7 @@
   overflow-y: auto;
   z-index: 10000;
 
-  background: rgba(0, 0, 0, 0.9);
+  background: rgba(0, 0, 0, 0.7);
 }
 
 .Content {


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[ZOS-348](https://wilderworld.atlassian.net/browse/ZOS-348)

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->

`Modal` overlay opacity was too high (`0.9` instead of `0.7`) and there was no blur effect.

## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->

- Reduced `Modal` overlay opacity to `0.7`
- Added a `5px` blur to the `Modal` overlay
- For browsers which don't support blur, set `Modal` overlay opacity to `0.85`

## 4. How can this behaviour be tested? (if applicable)

Open a modal, check the overlay matches Figma.

## 5. Other information

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->


[ZOS-348]: https://wilderworld.atlassian.net/browse/ZOS-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ