### PR TITLE
feat: add ReactNode type to button children prop

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { createElement, FC, useRef } from 'react';
+import React, { createElement, FC, ReactNode, useRef } from 'react';
 
 import { useButton } from '@react-aria/button';
 import classNames from 'classnames';
@@ -9,7 +9,7 @@ import { Spinner } from '../LoadingIndicator';
 
 export interface ButtonProps {
   className?: string;
-  children: string;
+  children: ReactNode | string;
   onPress?: () => void;
   onPressStart?: () => void;
   onPressEnd?: () => void;


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

Button component could only have children with type string - meaning an Icon or such element could not be used.

'To add an Icon element to the button label I need to update the Button Component in zUI. In order to be able to render an icon in the button label we need to update the children type in Button from string to ReactNode | string. As a result, an Icon can be rendered as part of the Button label.'

## 3. What is the new behaviour?

Button component children can now be any ReactNode rather than just a string.


[Related Jira Task](https://wilderworld.atlassian.net/jira/software/c/projects/ZOS/boards/33?modal=detail&selectedIssue=ZOS-356)


<img width="339" alt="Screenshot 2023-05-26 at 12 10 57" src="https://github.com/zer0-os/zUI/assets/39112648/6710e6fb-47f2-4b78-bcbd-a2c7dc564ebf">

<img width="339" alt="Screenshot 2023-05-26 at 12 12 47" src="https://github.com/zer0-os/zUI/assets/39112648/9f677985-807d-41d8-9c06-b8bd63cbee14">

<img width="339" alt="Screenshot 2023-05-26 at 12 12 49" src="https://github.com/zer0-os/zUI/assets/39112648/03e89e1b-6a66-4560-a36b-77d9a552db1f">


