### PR TITLE
fix: Remove global reset of buttons

### DIFF
--- a/src/components/ToastNotification/ToastNotification.module.scss
+++ b/src/components/ToastNotification/ToastNotification.module.scss
@@ -30,6 +30,9 @@
   }
 
   .ToastClose {
+    // button reset
+    all: unset;
+
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/ToastNotification/ToastNotification.module.scss
+++ b/src/components/ToastNotification/ToastNotification.module.scss
@@ -1,10 +1,5 @@
 @import '../../styles/theme';
 
-/* reset */
-button {
-  all: unset;
-}
-
 .ToastRoot {
   display: flex;
   flex-direction: row;

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -80,7 +80,7 @@ export const ToastNotification = ({
             {actionTitle}
           </Button>
         </Toast.Action>
-        <Toast.Close className={styles.ToastClose} asChild data-testid="toast-close-button">
+        <Toast.Close className={ToastClose} asChild data-testid="toast-close-button">
           <button onClick={handleOnClose}>
             <IconXClose size={24} />
           </button>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->

Removes a global style override of all buttons that changed how buttons were sized. Note that default buttons are rendered with box-sizing->border-box. In general, I don't think we want global overrides happening within specific component stylesheets. With bug:

![image](https://github.com/zer0-os/zUI/assets/43770/28f91e1f-8084-4c4e-92aa-9586f6c7e03c)


## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->

Returned to previous rendering:
![image](https://github.com/zer0-os/zUI/assets/43770/bfdf2350-1385-41f8-a5f1-c7e910429197)

## 4. How can this behaviour be tested? (if applicable)

## 5. Other information

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
