### PR TITLE
chore: bump minor (`0.22.2` -> `0.23.0`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero-tech/zui",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "Zero UI React Component Library",
   "scripts": {
     "about:clean": "echo 'Removes any existing build folders.'",


### PR DESCRIPTION
Bumps minor version from `0.22.2` to `0.23.0`. This will trigger an NPM publish!