### PR TITLE
fix(accordion): trigger hover and active state colours

### DIFF
--- a/src/components/Accordion/Accordion.module.scss
+++ b/src/components/Accordion/Accordion.module.scss
@@ -58,24 +58,16 @@ $group-border-radius: 0.5rem;
     font-family: inherit;
 
     &:hover {
-      background-color: $color-primary-2;
+      background-color: $color-primary-3;
       cursor: pointer;
     }
 
     &[data-state='open'] {
       background-color: $color-primary-3;
 
-      &:hover {
-        background-color: $color-primary-2;
-      }
-
       & > .Chevron {
         transform: rotate(180deg);
       }
-    }
-
-    &:active {
-      background-color: $color-primary-2;
     }
   }
 


### PR DESCRIPTION
Small iteration - The hover will now have the same effects as the conversation items in the conversation panel. The design for the accordion looks to be out of date.

The background modal colour of the rewards faq modal is currently the same colour as the hover colour currently set for the accordion triggers, meaning that there is no colour indication when hovering over these elements. 

This PR updates the colour of the on hover of the accordion trigger to the same as when the accordion is open.


https://deploy-preview-129--zui-storybook.netlify.app/?path=/story/data-display-accordion--low-contrast
