### PR TITLE
feat: implement 'isActive' state in avatar component

### DIFF
--- a/src/components/Avatar/Avatar.module.scss
+++ b/src/components/Avatar/Avatar.module.scss
@@ -10,7 +10,17 @@
   &:focus-within {
     border-radius: 50%;
     outline-offset: 0.25rem;
-    outline: 0.0625rem solid $color-success-9;
+    outline: 0.0625rem solid $color-secondary-11;
+  }
+
+  &.Active {
+    border-radius: 50%;
+    outline-offset: 0.25rem;
+    outline: 0.0625rem solid $color-secondary-11;
+
+    &[data-type='square'] {
+      border-radius: 0.5rem;
+    }
   }
 
   .Root {

--- a/src/components/Avatar/Avatar.module.scss
+++ b/src/components/Avatar/Avatar.module.scss
@@ -7,13 +7,7 @@
   font-size: 0.875rem;
   line-height: 150%;
 
-  &:focus-within {
-    border-radius: 50%;
-    outline-offset: 0.25rem;
-    outline: 0.0625rem solid $color-secondary-11;
-  }
-
-  &.Active {
+  &.isActive {
     border-radius: 50%;
     outline-offset: 0.25rem;
     outline: 0.0625rem solid $color-secondary-11;

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -104,6 +104,6 @@ describe('when image and user name are not available', () => {
 describe('when isActive is true', () => {
   test('should apply the active class', () => {
     const { container } = render(<Avatar {...DEFAULT_PROPS} isActive />);
-    expect(container.firstChild).toHaveClass('Active');
+    expect(container.firstChild).toHaveClass('isActive');
   });
 });

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -28,6 +28,16 @@ describe('when using default props', () => {
     expect(container.firstChild).toHaveAttribute('data-type', 'circle');
   });
 
+  test('should be small size', () => {
+    const { container } = render(<Avatar {...DEFAULT_PROPS} size="small" />);
+    expect(container.firstChild).toHaveAttribute('data-size', 'small');
+  });
+
+  test('should be extra small size', () => {
+    const { container } = render(<Avatar {...DEFAULT_PROPS} size="extra small" />);
+    expect(container.firstChild).toHaveAttribute('data-size', 'extra small');
+  });
+
   test('should be square shape', () => {
     const { container } = render(<Avatar {...DEFAULT_PROPS} type="square" />);
     expect(container.firstChild).toHaveAttribute('data-type', 'square');
@@ -88,5 +98,12 @@ describe('when image and user name are not available', () => {
       const items = container.getElementsByClassName('DefaultIcon');
       expect(items.length).toBe(1);
     });
+  });
+});
+
+describe('when isActive is true', () => {
+  test('should apply the active class', () => {
+    const { container } = render(<Avatar {...DEFAULT_PROPS} isActive />);
+    expect(container.firstChild).toHaveClass('Active');
   });
 });

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -33,7 +33,7 @@ export const Avatar = ({
 
   return (
     <div
-      className={classNames(styles.Avatar, { [styles.Active]: isActive })}
+      className={classNames(styles.Avatar, { [styles.isActive]: isActive })}
       data-type={type}
       data-size={size}
       tabIndex={0}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 
 import * as RadixAvatar from '@radix-ui/react-avatar';
+
+import { Status } from '../Status';
 import { IconCurrencyEthereum } from '../Icons';
 
 import { AVATAR_ICON_SIZE } from './AvatarIconSize.constants';
+
+import classNames from 'classnames';
 import styles from './Avatar.module.scss';
-import { Status } from '../Status';
 
 export interface AvatarProps {
   imageURL?: string;
@@ -14,6 +17,7 @@ export interface AvatarProps {
   userFriendlyName?: string;
   badgeContent?: string;
   statusType?: 'active' | 'idle' | 'busy' | 'offline' | 'unread';
+  isActive?: boolean;
 }
 
 export const Avatar = ({
@@ -22,12 +26,18 @@ export const Avatar = ({
   imageURL,
   userFriendlyName,
   statusType,
-  badgeContent
+  badgeContent,
+  isActive
 }: AvatarProps) => {
   const initials = userFriendlyName && getInitials(userFriendlyName);
 
   return (
-    <div className={styles.Avatar} data-type={type} data-size={size} tabIndex={0}>
+    <div
+      className={classNames(styles.Avatar, { [styles.Active]: isActive })}
+      data-type={type}
+      data-size={size}
+      tabIndex={0}
+    >
       <RadixAvatar.Root className={styles.Root}>
         <RadixAvatar.Image className={styles.Image} src={imageURL} alt="avatar" />
         <RadixAvatar.Fallback className={styles.Fallback} delayMs={600}>

--- a/src/components/DropdownMenu/DropdownMenu.scss
+++ b/src/components/DropdownMenu/DropdownMenu.scss
@@ -6,6 +6,7 @@
   border: none;
   cursor: pointer;
   font-size: inherit;
+  outline: none;
 }
 
 .zui-dropdown-menu {


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

The reason for this change is so we can use Avatar as the trigger for the DropdownMenu component with an `isActive` style. The `focus-within` styling isn't enough to currently satisfy this, as shown in the recordings below.

The issue we're currently facing (recording below) is because the focus-within pseudo class only applies to an element that has received focus itself, or has a descendant which has received focus. However, when the DropdownMenu opens, the Avatar loses its focus because focus is now given to the dropdown menu.

The solution is to manage a state to track whether the dropdown menu is opened or not, and then conditionally add a class to the Avatar to simulate :focus-within.

Here I have created a state variable called isActive in the Avatar component. This means in the DropdownMenu we can set its value with the help of the onOpenChange prop, and use this state variable to conditionally add the focused class to the Avatar component.

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

Unable to set an active state on Avatar.

## 3. What is the new behaviour?

Able to set an active state when using Avatar.
Also a small change, removing outline from dropdown trigger.

Avatar used with DropdownMenu before change looks like this:

https://github.com/zer0-os/zUI/assets/39112648/76f5bc79-732a-4e67-b017-dd4c860bd30b

What the Avatar used with DropdownMenu after change will look like:

https://github.com/zer0-os/zUI/assets/39112648/ea8cb7a3-803c-4d2e-ad08-1a06806457e0

