### PR TITLE
feat: add radix dropdown menu arrow pointer

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.scss
+++ b/src/components/DropdownMenu/DropdownMenu.scss
@@ -37,4 +37,10 @@
     user-select: none;
     cursor: pointer;
   }
+
+  .zui-dropdown-pointer {
+    fill: $color-primary-2;
+    height: 16px;
+    width: 32px;
+  }
 }

--- a/src/components/DropdownMenu/DropdownMenu.scss
+++ b/src/components/DropdownMenu/DropdownMenu.scss
@@ -38,7 +38,7 @@
     cursor: pointer;
   }
 
-  .zui-dropdown-pointer {
+  .zui-dropdown-arrow {
     fill: $color-primary-2;
     height: 16px;
     width: 32px;

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 const Template: ComponentStory<typeof DropdownMenu> = args => {
   return (
-    <div style={{ margin: '300px' }}>
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', width: '100%' }}>
       <DropdownMenu
         {...args}
         items={[
@@ -48,9 +48,8 @@ CustomTrigger.args = {
   trigger: <IconArrowDownLeft />
 };
 
-export const CustomeTriggerWithPointer = Template.bind({});
-CustomTrigger.args = {
-  trigger: <IconArrowDownLeft />,
+export const TriggerWithPointer = Template.bind({});
+TriggerWithPointer.args = {
   showPointer: true,
   alignMenu: 'center'
 };

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -11,26 +11,28 @@ export default {
 
 const Template: ComponentStory<typeof DropdownMenu> = args => {
   return (
-    <DropdownMenu
-      {...args}
-      items={[
-        {
-          id: 'dropdown_menu_1',
-          label: 'Apple',
-          onSelect: () => console.log('you clicked Apple!')
-        },
-        {
-          id: 'dropdown_menu_2',
-          label: 'Orange',
-          onSelect: () => console.log('you clicked Orange!')
-        },
-        {
-          id: 'pear',
-          label: 'Pear',
-          onSelect: () => console.log('you clicked Pear!')
-        }
-      ]}
-    />
+    <div style={{ margin: '300px' }}>
+      <DropdownMenu
+        {...args}
+        items={[
+          {
+            id: 'dropdown_menu_1',
+            label: 'Apple',
+            onSelect: () => console.log('you clicked Apple!')
+          },
+          {
+            id: 'dropdown_menu_2',
+            label: 'Orange',
+            onSelect: () => console.log('you clicked Orange!')
+          },
+          {
+            id: 'pear',
+            label: 'Pear',
+            onSelect: () => console.log('you clicked Pear!')
+          }
+        ]}
+      />
+    </div>
   );
 };
 
@@ -44,4 +46,11 @@ TextTrigger.args = {
 export const CustomTrigger = Template.bind({});
 CustomTrigger.args = {
   trigger: <IconArrowDownLeft />
+};
+
+export const CustomeTriggerWithPointer = Template.bind({});
+CustomTrigger.args = {
+  trigger: <IconArrowDownLeft />,
+  showPointer: true,
+  alignMenu: 'center'
 };

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -50,6 +50,6 @@ CustomTrigger.args = {
 
 export const TriggerWithPointer = Template.bind({});
 TriggerWithPointer.args = {
-  showPointer: true,
+  showArrow: true,
   alignMenu: 'center'
 };

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -159,8 +159,8 @@ describe('<DropdownMenu />', () => {
       expect(arrow).toBeNull();
     });
 
-    test('should render arrow if alignMenu is center and showPointer is true', () => {
-      render(<DropdownMenu {...DEFAULT_PROPS} alignMenu="center" showPointer={true} />);
+    test('should render arrow if alignMenu is center and showArrow is true', () => {
+      render(<DropdownMenu {...DEFAULT_PROPS} alignMenu="center" showArrow={true} />);
       const content = screen.getByTestId('content');
 
       const arrow = screen.getByTestId('arrow');
@@ -168,8 +168,8 @@ describe('<DropdownMenu />', () => {
       expect(arrow.parentElement).toBe(content);
     });
 
-    test('should not render arrow if alignMenu is not center even though showPointer is true', () => {
-      render(<DropdownMenu {...DEFAULT_PROPS} alignMenu="start" showPointer={true} />);
+    test('should not render arrow if alignMenu is not center even though showArrow is true', () => {
+      render(<DropdownMenu {...DEFAULT_PROPS} alignMenu="start" showArrow={true} />);
 
       const arrow = screen.queryByTestId('arrow');
       expect(arrow).toBeNull();

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 
 import { DropdownMenu, DropdownItem } from '.';
 import {
+  DropdownMenuArrowProps,
   DropdownMenuRootContentProps,
   DropdownMenuTriggerProps,
   DropdownMenuContentProps,
@@ -24,6 +25,7 @@ const mockRadixRoot = jest.fn();
 const mockRadixTrigger = jest.fn();
 const mockRadixContent = jest.fn();
 const mockRadixItem = jest.fn();
+const mockRadixArrow = jest.fn();
 
 jest.mock('@radix-ui/react-dropdown-menu', () => ({
   Root: (props: DropdownMenuRootContentProps) => {
@@ -49,6 +51,10 @@ jest.mock('@radix-ui/react-dropdown-menu', () => ({
   Item: (props: DropdownMenuItemProps) => {
     mockRadixItem(props);
     return <div className={'mock-item ' + props.className}>{props.children}</div>;
+  },
+  Arrow: (props: DropdownMenuArrowProps) => {
+    mockRadixArrow(props);
+    return <div data-testid="arrow">{props.children}</div>;
   }
 }));
 
@@ -142,6 +148,31 @@ describe('<DropdownMenu />', () => {
       render(<DropdownMenu {...DEFAULT_PROPS} open={true} defaultOpen={true} />);
 
       expect(mockRadixRoot).toBeCalledWith(expect.objectContaining({ open: true, defaultOpen: true }));
+    });
+  });
+
+  describe('dropdown arrow', () => {
+    test('should not render arrow by default', () => {
+      render(<DropdownMenu {...DEFAULT_PROPS} />);
+
+      const arrow = screen.queryByTestId('arrow');
+      expect(arrow).toBeNull();
+    });
+
+    test('should render arrow if alignMenu is center and showPointer is true', () => {
+      render(<DropdownMenu {...DEFAULT_PROPS} alignMenu="center" showPointer={true} />);
+      const content = screen.getByTestId('content');
+
+      const arrow = screen.getByTestId('arrow');
+      expect(arrow).not.toBeNull();
+      expect(arrow.parentElement).toBe(content);
+    });
+
+    test('should not render arrow if alignMenu is not center even though showPointer is true', () => {
+      render(<DropdownMenu {...DEFAULT_PROPS} alignMenu="start" showPointer={true} />);
+
+      const arrow = screen.queryByTestId('arrow');
+      expect(arrow).toBeNull();
     });
   });
 });

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -59,7 +59,7 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       open,
       defaultOpen,
       onOpenChange,
-      showPointer = true
+      showPointer
     },
     ref
   ) => {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, ReactNode } from 'react';
 
 import {
+  Arrow as RadixUIDropdownMenuArrow,
   DropdownMenuProps as RadixUIDropdownMenuProps,
   DropdownMenuContentProps as RadixUIDropdownMenuContentProps,
   Root as RadixUIDropdownMenuRoot,
@@ -43,6 +44,7 @@ export interface DropdownMenuProps {
 
   /** Class to apply to the menu */
   menuClassName?: string;
+  showPointer?: boolean;
 }
 
 export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
@@ -56,7 +58,8 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       side = 'bottom',
       open,
       defaultOpen,
-      onOpenChange
+      onOpenChange,
+      showPointer = true
     },
     ref
   ) => {
@@ -73,6 +76,7 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
           side={side}
           ref={ref}
         >
+          {alignMenu === 'center' && showPointer && <RadixUIDropdownMenuArrow className="zui-dropdown-pointer" />}
           {items.map(item => (
             <RadixUIDropdownMenuItem
               className={classNames('zui-dropdown-item', item.className)}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -44,7 +44,7 @@ export interface DropdownMenuProps {
 
   /** Class to apply to the menu */
   menuClassName?: string;
-  showPointer?: boolean;
+  showArrow?: boolean;
 }
 
 export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
@@ -59,7 +59,7 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       open,
       defaultOpen,
       onOpenChange,
-      showPointer
+      showArrow
     },
     ref
   ) => {
@@ -76,7 +76,7 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
           side={side}
           ref={ref}
         >
-          {alignMenu === 'center' && showPointer && <RadixUIDropdownMenuArrow className="zui-dropdown-pointer" />}
+          {alignMenu === 'center' && showArrow && <RadixUIDropdownMenuArrow className="zui-dropdown-arrow" />}
           {items.map(item => (
             <RadixUIDropdownMenuItem
               className={classNames('zui-dropdown-item', item.className)}


### PR DESCRIPTION

The arrow pointer will only be visible if `showPointer` is true, and `alignMenu` is set to center. The reason for this is because the pointer will not line up with the `DropdownMenu` if the alignment is `start` or `end` due to the border radius we have on the `DropdownMenu`. For this case, design would have to provide further input for a solution on how to line up the pointer. As this is not required for our needs right now, I am adding what is necessary for the current requirements.

https://github.com/zer0-os/zUI/assets/39112648/de1415a8-1335-4718-b1c4-bed62fba0c15


Alignment issue that would need to be addressed if we ever require this (using red to highlight):

<img width="579" alt="Screenshot 2023-07-03 at 17 55 22" src="https://github.com/zer0-os/zUI/assets/39112648/b1a1048b-2c5b-4fd3-8abd-f6b8be9b870c">
