### PR TITLE
feat: add tab index prop to avatar component

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -58,3 +58,10 @@ OnlyAvatar.args = {
   userFriendlyName: 'Mic Brooklyn',
   imageURL: 'https://picsum.photos/200/300'
 };
+
+export const DisabledTabIndex = Template.bind({});
+DisabledTabIndex.args = {
+  userFriendlyName: 'Mic Brooklyn',
+  imageURL: 'https://picsum.photos/200/300',
+  tabIndex: -1
+};

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -107,3 +107,17 @@ describe('when isActive is true', () => {
     expect(container.firstChild).toHaveClass('isActive');
   });
 });
+
+describe('when tabIndex is not specified (default value)', () => {
+  test('should have tabIndex attribute set to 0', () => {
+    const { container } = render(<Avatar {...DEFAULT_PROPS} />);
+    expect(container.firstChild).toHaveAttribute('tabIndex', '0');
+  });
+});
+
+describe('when tabIndex is set to -1', () => {
+  test('should have tabIndex attribute set to -1', () => {
+    const { container } = render(<Avatar {...DEFAULT_PROPS} tabIndex={-1} />);
+    expect(container.firstChild).toHaveAttribute('tabIndex', '-1');
+  });
+});

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -18,6 +18,7 @@ export interface AvatarProps {
   badgeContent?: string;
   statusType?: 'active' | 'idle' | 'busy' | 'offline' | 'unread';
   isActive?: boolean;
+  tabIndex?: number;
 }
 
 export const Avatar = ({
@@ -27,7 +28,8 @@ export const Avatar = ({
   userFriendlyName,
   statusType,
   badgeContent,
-  isActive
+  isActive,
+  tabIndex = 0
 }: AvatarProps) => {
   const initials = userFriendlyName && getInitials(userFriendlyName);
 
@@ -36,7 +38,7 @@ export const Avatar = ({
       className={classNames(styles.Avatar, { [styles.isActive]: isActive })}
       data-type={type}
       data-size={size}
-      tabIndex={0}
+      tabIndex={tabIndex}
     >
       <RadixAvatar.Root className={styles.Root}>
         <RadixAvatar.Image className={styles.Image} src={imageURL} alt="avatar" />


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

- tab index set as '0' on div container of `Avatar`. As a result, the element is included in the normal tab order and can receive focus when tabbing through the page.
- in some scenarios we want to be able to remove `Avatar` from the normal tab order via the tab keydown. 

## 3. What is the new behaviour?

- adds prop to set tab index to the desired value for tab order. 
- default tab index is set to `0` to ensure behaviour does not change on current uses of `Avatar` and its tab order i.e. profile avatar. 

## 4. How can this behaviour be tested? (if applicable)

- you can run storybook (or go to the deployment link created on this PR), type `Avatar` in the search input and select the `DisabledTabIndex` option/template. Click just above the `Avatar` component and press tab on the keyboard. The `Avatar` should not be outlined/focused like it is when using one of the other story templates. 



https://github.com/zer0-os/zUI/assets/39112648/fded1aac-04e2-463a-9c09-3d0e53ca4dfa

