### PR TITLE
fix: icon button sizing and icon sizing to match

### DIFF
--- a/src/components/IconButton/IconButton.scss
+++ b/src/components/IconButton/IconButton.scss
@@ -1,14 +1,16 @@
 @use '../../styles/theme' as theme;
 
 .zui-iconButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   border-radius: 50%;
   padding: 2px;
   line-height: 0px;
-
   cursor: pointer;
   background: none;
   border: none;
-  display: inline-block;
   margin: 0px;
 
   color: theme.$color-greyscale-12;

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -13,8 +13,37 @@ const Template: ComponentStory<typeof IconButton> = args => {
   return <IconButton {...args} />;
 };
 
-export const CloseIcon = Template.bind({ title: 'Close Icon Button' });
-CloseIcon.args = {
+export const CloseIconLarge = Template.bind({ title: 'Close Icon Button' });
+CloseIconLarge.args = {
   onClick: (): void => null,
-  Icon: IconXClose
+  Icon: IconXClose,
+  size: 'large'
+};
+
+export const CloseIconSmall = Template.bind({ title: 'Close Icon Button' });
+CloseIconSmall.args = {
+  onClick: (): void => null,
+  Icon: IconXClose,
+  size: 'small'
+};
+
+export const CloseIconXSmall = Template.bind({ title: 'Close Icon Button' });
+CloseIconXSmall.args = {
+  onClick: (): void => null,
+  Icon: IconXClose,
+  size: 'x-small'
+};
+
+export const CloseIconCustomLarger = Template.bind({ title: 'Close Icon Button' });
+CloseIconCustomLarger.args = {
+  onClick: (): void => null,
+  Icon: IconXClose,
+  size: 68
+};
+
+export const CloseIconCustomSmaller = Template.bind({ title: 'Close Icon Button' });
+CloseIconCustomSmaller.args = {
+  onClick: (): void => null,
+  Icon: IconXClose,
+  size: 12
 };

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -89,7 +89,7 @@ describe('IconButton', () => {
     expect(getByRole('button')).toHaveClass('zui-iconButton-variant-primary');
   });
 
-  it('renders large size', () => {
+  it('renders large size when "large" is passed in', () => {
     renderComponent({
       Icon: IconXClose,
       label: 'the-label',
@@ -104,7 +104,7 @@ describe('IconButton', () => {
     });
   });
 
-  it('renders small size', () => {
+  it('renders small size when "small" is passed in', () => {
     renderComponent({
       Icon: IconXClose,
       label: 'the-label',
@@ -119,7 +119,7 @@ describe('IconButton', () => {
     });
   });
 
-  it('renders x small size', () => {
+  it('renders x small size when "x-small" is passed in', () => {
     renderComponent({
       Icon: IconXClose,
       label: 'the-label',
@@ -130,6 +130,36 @@ describe('IconButton', () => {
     expect(iconRender).toHaveBeenLastCalledWith({
       label: 'the-label',
       size: 24,
+      isFilled: false
+    });
+  });
+
+  it('renders custom size when a number is passed in (custom smaller)', () => {
+    renderComponent({
+      Icon: IconXClose,
+      label: 'the-label',
+      size: 12,
+      isFilled: false
+    });
+
+    expect(iconRender).toHaveBeenLastCalledWith({
+      label: 'the-label',
+      size: 12,
+      isFilled: false
+    });
+  });
+
+  it('renders custom size when a number is passed in (custom larger) ', () => {
+    renderComponent({
+      Icon: IconXClose,
+      label: 'the-label',
+      size: 48,
+      isFilled: false
+    });
+
+    expect(iconRender).toHaveBeenLastCalledWith({
+      label: 'the-label',
+      size: 48,
       isFilled: false
     });
   });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -50,6 +50,12 @@ export const IconButton = ({
     onClick(event);
   };
 
+  const buttonSize = getSize(size);
+  const buttonStyle = {
+    width: buttonSize ? `${buttonSize}px` : undefined,
+    height: buttonSize ? `${buttonSize}px` : undefined
+  };
+
   return (
     <button
       className={classNames(
@@ -61,8 +67,9 @@ export const IconButton = ({
       disabled={isDisabled}
       onClick={handleOnClick}
       type={type}
+      style={buttonStyle}
     >
-      <Icon label={label} size={getSize(size)} isFilled={isFilled} />
+      <Icon label={label} size={buttonSize} isFilled={isFilled} />
     </button>
   );
 };


### PR DESCRIPTION
When passing `size` to the `IconButton`, the button itself is not sized correctly around the `Icon`. This PR fixes this issue by adding an inline style to the button wrapped around the `Icon` component which uses the `size` prop to determine its `width` and `height`.

Now, in zOS (or zApps), you can pass in a size `large`, `small`, `x-small` or simply a number of pixels i.e. something larger like - `48`, or something smaller like - `12`. 

Example - if `large` is set as the `size` for `IconButton`, the `Icon` svg itself will be `40` in width and height, and the button wrapped around the `Icon` will also have a width of `40` and height of `40`.

Examples:
CUSTOM SMALL (`12` number passed in)
<img width="1248" alt="Screenshot 2023-08-11 at 12 37 18" src="https://github.com/zer0-os/zUI/assets/39112648/ae5076c9-d820-4954-93ac-aa37e2a8f39b">

CUSTOM LARGE (`68` number passed in)
<img width="1248" alt="Screenshot 2023-08-11 at 12 37 13" src="https://github.com/zer0-os/zUI/assets/39112648/7b52b1b0-2f6d-48da-86b3-9a430d42cb65">

`x-small` passed in
<img width="1248" alt="Screenshot 2023-08-11 at 12 37 09" src="https://github.com/zer0-os/zUI/assets/39112648/f7f0890b-0be0-4166-9dc4-b8003ed4c815">

`small` passed in
<img width="1248" alt="Screenshot 2023-08-11 at 12 37 05" src="https://github.com/zer0-os/zUI/assets/39112648/0190ac1f-89dd-4c7a-a0a1-a15be82974f7">

`large` passed in
<img width="1248" alt="Screenshot 2023-08-11 at 12 36 58" src="https://github.com/zer0-os/zUI/assets/39112648/b543588f-25ac-482e-b0a7-9bfd9fd86ea5">
