### PR TITLE
feat: tweak ModalConfirmation behaviour

### DIFF
--- a/src/components/Modal/ModalConfirmation/ModalConfirmation.test.tsx
+++ b/src/components/Modal/ModalConfirmation/ModalConfirmation.test.tsx
@@ -52,6 +52,18 @@ jest.mock('@radix-ui/react-dialog', () => ({
   }
 }));
 
+const buttonRender = jest.fn();
+jest.mock('../../Button', () => ({
+  Button: (props: any) => {
+    buttonRender(props['data-testid'], props);
+    return (
+      <div data-testid={props['data-testid']} onClick={props.onPress}>
+        {props.children}
+      </div>
+    );
+  }
+}));
+
 afterEach(() => {
   cleanup();
   jest.clearAllMocks();
@@ -85,9 +97,9 @@ test('should render cancel button', () => {
 });
 
 test('should render confirm button', () => {
-  renderComponent();
+  renderComponent({ confirmationLabel: 'confirm label' });
 
-  expect(screen.getByTestId('modal-confirm-button')).toBeInTheDocument();
+  expect(screen.getByTestId('modal-confirm-button')).toHaveTextContent('confirm label');
 });
 
 test('should call onCancel', () => {
@@ -108,4 +120,10 @@ test('should call onConfirm', () => {
   fireEvent.click(confirmButton);
 
   expect(onConfirm).toHaveBeenCalled();
+});
+
+test('should set the confirm button to loading when inProgress', () => {
+  renderComponent({ inProgress: true });
+
+  expect(buttonRender).toHaveBeenCalledWith('modal-confirm-button', expect.objectContaining({ isLoading: true }));
 });

--- a/src/components/Modal/ModalConfirmation/ModalConfirmation.tsx
+++ b/src/components/Modal/ModalConfirmation/ModalConfirmation.tsx
@@ -43,7 +43,7 @@ export const ModalConfirmation: React.FC<ModalConfirmationProps> = ({
 
       <div className={styles.FooterActions} data-testid="modal-actions">
         <DialogClose asChild>
-          <Button variant="secondary" onPress={onCancel} data-testid="modal-cancel-button">
+          <Button variant="text" onPress={onCancel} data-testid="modal-cancel-button">
             {cancelLabel}
           </Button>
         </DialogClose>

--- a/src/components/Modal/ModalConfirmation/ModalConfirmation.tsx
+++ b/src/components/Modal/ModalConfirmation/ModalConfirmation.tsx
@@ -13,6 +13,7 @@ export interface ModalConfirmationProps extends DialogProps {
   title: string;
   cancelLabel: string;
   confirmationLabel: string;
+  inProgress?: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }
@@ -23,6 +24,7 @@ export const ModalConfirmation: React.FC<ModalConfirmationProps> = ({
   title,
   cancelLabel,
   confirmationLabel,
+  inProgress,
   onCancel,
   onConfirm,
   ...rest
@@ -46,7 +48,7 @@ export const ModalConfirmation: React.FC<ModalConfirmationProps> = ({
           </Button>
         </DialogClose>
         <DialogClose asChild>
-          <Button variant="negative" onPress={onConfirm} data-testid="modal-confirm-button">
+          <Button variant="negative" onPress={onConfirm} data-testid="modal-confirm-button" isLoading={inProgress}>
             {confirmationLabel}
           </Button>
         </DialogClose>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 3. What is the new behaviour?

<!-- Please describe the behaviour or changes that are being added by this PR. -->
1. ModalConfirmation now takes an `inProgress` flag. When true the primary button will switch to the loading state.
2. Also changed the cancel button from the primary variant to text to match a little more closely with design

