### PR TITLE
feat: update search input inset styles

### DIFF
--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -1,4 +1,6 @@
 @import '../../styles/theme';
+@import '../../styles/typography';
+@import '../../styles/glass';
 
 .Container {
   display: flex;
@@ -24,30 +26,29 @@
   }
 
   .Wrapper {
+    @include glass-input-inset-default;
+
     display: flex;
     align-items: center;
     position: relative;
-    padding: 0.25rem 0.5rem;
     gap: 0.5rem;
 
     border-radius: 0.5rem;
-    border: 1px solid $color-greyscale-7;
 
     cursor: text;
 
     transition: border-color 0.1s ease;
 
     &:focus-within {
-      border-color: $color-primary-9;
+      @include glass-input-inset-active;
     }
 
     &[data-size='small'] {
-      padding: 0.375rem 0.5rem; // 6px 8px
-      height: 1.125rem;
+      padding: 6px 9px 6px 12px;
     }
 
     &[data-size='large'] {
-      height: 1.875rem;
+      padding: 8px 9px 8px 17px;
     }
 
     &[data-status='error'] {
@@ -77,13 +78,25 @@
     }
 
     .Input {
+      @include glass-text-primary-color;
       background: none;
-      color: $color-greyscale-12;
       border: none;
-      font-size: 0.875rem;
-      line-height: 1.05625rem;
       flex: 1;
       outline: none;
+      padding: 0;
+
+      &[data-size='small'] {
+        font-size: $size-small;
+        font-weight: 400;
+        line-height: 20px;
+      }
+
+      &[data-size='large'] {
+        font-size: $size-default;
+        font-weight: 400;
+        line-height: 24px;
+        max-height: 24px;
+      }
 
       &:-webkit-autofill {
         transition: background 500000s ease-in-out 0s;

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -26,6 +26,11 @@ describe('<Input />', () => {
     expect(screen.getByTestId('zui-input-wrapper')).toHaveAttribute('data-size', 'large');
   });
 
+  test('should set size attribute on input', () => {
+    render(<Input {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('zui-input')).toHaveAttribute('data-size', 'large');
+  });
+
   test('should set status attribute to error on error', () => {
     render(<Input {...DEFAULT_PROPS} error={true} />);
     expect(screen.getByTestId('zui-input-wrapper')).toHaveAttribute('data-status', 'error');

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -94,6 +94,7 @@ export const Input = forwardRef<HTMLDivElement, InputProps>(
             className={classNames(styles.Input, inputClassName)}
             data-testid="zui-input"
             onChange={handleOnChange}
+            data-size={size}
             ref={inputRef}
             value={value}
             disabled={isDisabled}

--- a/src/components/Input/SearchInput.module.scss
+++ b/src/components/Input/SearchInput.module.scss
@@ -13,16 +13,8 @@
 }
 
 .SearchIcon {
-  &[data-is-searching] {
-    svg path {
-      stroke: $color-greyscale-12;
-    }
-  }
-
   svg path {
     stroke: $color-greyscale-11;
     transition: stroke 0.1s ease-in-out;
   }
-
-  padding-left: 8px;
 }

--- a/src/styles/_glass.scss
+++ b/src/styles/_glass.scss
@@ -1,0 +1,23 @@
+@use './theme' as theme;
+
+@mixin glass-input-inset-default {
+  background: rgba(167, 163, 163, 0.05);
+  box-shadow: -2px -2px 4px 0px rgba(246, 244, 246, 0.05) inset, 2px 2px 4px -1px rgba(10, 10, 10, 0.4) inset;
+}
+
+@mixin glass-input-inset-active {
+  background: rgba(163, 162, 163, 0.1);
+  box-shadow: -2px -2px 4px 0px rgba(246, 244, 246, 0.05) inset, 2px 2px 4px -1px rgba(10, 10, 10, 0.4) inset;
+}
+
+@mixin glass-text-primary-color {
+  color: $color-greyscale-transparency-12;
+}
+
+@mixin glass-text-secondary-color {
+  color: $color-greyscale-transparency-11;
+}
+
+@mixin glass-text-tertiary-color {
+  color: $color-greyscale-transparency-9;
+}


### PR DESCRIPTION
Updates the inset styles of the Input component including the Search Input.
Adds a `_glass` stylesheet.


<img width="384" alt="Screenshot 2023-12-15 at 10 22 55" src="https://github.com/zer0-os/zUI/assets/39112648/4a123a11-1084-448e-96c5-8f078eba88b5">
