### PR TITLE
feat: update password input icon button size

### DIFF
--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -15,7 +15,9 @@ export const PasswordInput = (props: PasswordInputProps) => {
 
   return (
     <Input
-      endEnhancer={<IconButton Icon={isHidden ? IconEye : IconEyeOff} onClick={toggleVisiblity} type={'button'} />}
+      endEnhancer={
+        <IconButton Icon={isHidden ? IconEye : IconEyeOff} onClick={toggleVisiblity} type={'button'} size={24} />
+      }
       type={isHidden ? 'password' : 'text'}
       {...props}
     />

--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -16,7 +16,12 @@ export const PasswordInput = (props: PasswordInputProps) => {
   return (
     <Input
       endEnhancer={
-        <IconButton Icon={isHidden ? IconEye : IconEyeOff} onClick={toggleVisiblity} type={'button'} size={24} />
+        <IconButton
+          Icon={isHidden ? IconEye : IconEyeOff}
+          onClick={toggleVisiblity}
+          type={'button'}
+          size={props.size === 'large' ? 24 : 20}
+        />
       }
       type={isHidden ? 'password' : 'text'}
       {...props}


### PR DESCRIPTION
- Updates password input icon button size as this was causing input sizing to be slightly off when using in zOS.

<img width="315" alt="Screenshot 2023-12-15 at 11 37 23" src="https://github.com/zer0-os/zUI/assets/39112648/c7e8b0d7-6379-4ce9-a743-7e965b8300cf">


The issue in ZOS:

<img width="454" alt="Screenshot 2023-12-15 at 11 37 55" src="https://github.com/zer0-os/zUI/assets/39112648/3f270467-a3cb-4d1a-84f8-3f0c78978de8">
