### PR TITLE
Add a width to the inner Input to allow proper sizing

### DIFF
--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -82,6 +82,7 @@
       background: none;
       border: none;
       flex: 1;
+      width: 1px; // Force a width to allow flex to grow/shrink as necessary
       outline: none;
       padding: 0;
 


### PR DESCRIPTION
Add a forced width to the inner `input` element to allow the flex display to size properly
