### PR TITLE
feat: remove avatar status border and update position

### DIFF
--- a/src/components/Avatar/Avatar.module.scss
+++ b/src/components/Avatar/Avatar.module.scss
@@ -117,9 +117,8 @@
 
   .Status {
     position: absolute;
-    bottom: -0.125rem;
-    right: -0.125rem;
-    border: 0.125rem solid $color-primary-1;
+    top: 32px;
+    left: 32px;
   }
 
   .DefaultIcon {


### PR DESCRIPTION
- Removes border from the `Avatar` status and updates the position as per figma designs.

Before:
<img width="399" alt="Screenshot 2023-12-15 at 18 59 44" src="https://github.com/zer0-os/zOS/assets/39112648/32f518c6-811f-437b-9a6d-5396ac01b053">

After:
<img width="399" alt="Screenshot 2023-12-15 at 18 54 38" src="https://github.com/zer0-os/zOS/assets/39112648/d93b76ee-d166-4a7a-b3e1-34c87a89b3d7">