### PR TITLE
feat: add raised class for avatar

### DIFF
--- a/src/components/Avatar/Avatar.module.scss
+++ b/src/components/Avatar/Avatar.module.scss
@@ -9,22 +9,7 @@
   line-height: 150%;
 
   border-radius: 9999px;
-
   @include glass-separator-primary;
-  @include glass-shadow-low;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    border-radius: inherit;
-    z-index: -1;
-
-    @include glass-materials-raised;
-  }
 
   &.isActive {
     border-radius: 50%;
@@ -33,6 +18,23 @@
 
     &[data-type='square'] {
       border-radius: 0.5rem;
+    }
+  }
+
+  &.isRaised {
+    @include glass-shadow-low;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      border-radius: inherit;
+      z-index: -1;
+
+      @include glass-materials-raised;
     }
   }
 
@@ -66,6 +68,22 @@
     font-size: 8px;
     line-height: 11px;
     color: $color-secondary-11;
+
+    &.isRaised {
+      @include glass-shadow-low;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        border-radius: inherit;
+
+        @include glass-materials-raised;
+      }
+    }
   }
 
   .Image {

--- a/src/components/Avatar/Avatar.module.scss
+++ b/src/components/Avatar/Avatar.module.scss
@@ -68,22 +68,6 @@
     font-size: 8px;
     line-height: 11px;
     color: $color-secondary-11;
-
-    &.isRaised {
-      @include glass-shadow-low;
-
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        border-radius: inherit;
-
-        @include glass-materials-raised;
-      }
-    }
   }
 
   .Image {

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -108,6 +108,13 @@ describe('when isActive is true', () => {
   });
 });
 
+describe('when isRaised is true', () => {
+  test('should apply the Raised class', () => {
+    const { container } = render(<Avatar {...DEFAULT_PROPS} isRaised />);
+    expect(container.firstChild).toHaveClass('isRaised');
+  });
+});
+
 describe('when tabIndex is not specified (default value)', () => {
   test('should have tabIndex attribute set to 0', () => {
     const { container } = render(<Avatar {...DEFAULT_PROPS} />);

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -55,18 +55,17 @@ export const Avatar = ({
         </RadixAvatar.Fallback>
       </RadixAvatar.Root>
       {size != 'extra small' && statusType && <Status className={styles.Status} type={statusType} />}
-      {size != 'extra small' && badgeContent && <AvatarBadge badgeContent={badgeContent} isRaised={isRaised} />}
+      {size != 'extra small' && badgeContent && <AvatarBadge badgeContent={badgeContent} />}
     </div>
   );
 };
 
 interface StatusBadgeTypeProps {
   badgeContent: AvatarProps['badgeContent'];
-  isRaised?: AvatarProps['isRaised'];
 }
 
-const AvatarBadge = ({ badgeContent, isRaised }: StatusBadgeTypeProps) => {
-  return <div className={classNames(styles.Badge, { [styles.isRaised]: isRaised })}> {badgeContent}</div>;
+const AvatarBadge = ({ badgeContent }: StatusBadgeTypeProps) => {
+  return <div className={styles.Badge}>{badgeContent}</div>;
 };
 
 /**

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -65,7 +65,7 @@ interface StatusBadgeTypeProps {
 }
 
 const AvatarBadge = ({ badgeContent }: StatusBadgeTypeProps) => {
-  return <div className={styles.Badge}>{badgeContent}</div>;
+  return <div className={styles.Badge}> {badgeContent}</div>;
 };
 
 /**

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -18,6 +18,7 @@ export interface AvatarProps {
   badgeContent?: string;
   statusType?: 'active' | 'idle' | 'busy' | 'offline' | 'unread';
   isActive?: boolean;
+  isRaised?: boolean;
   tabIndex?: number;
 }
 
@@ -29,13 +30,14 @@ export const Avatar = ({
   statusType,
   badgeContent,
   isActive,
+  isRaised,
   tabIndex = 0
 }: AvatarProps) => {
   const initials = userFriendlyName && getInitials(userFriendlyName);
 
   return (
     <div
-      className={classNames(styles.Avatar, { [styles.isActive]: isActive })}
+      className={classNames(styles.Avatar, { [styles.isActive]: isActive, [styles.isRaised]: isRaised })}
       data-type={type}
       data-size={size}
       tabIndex={tabIndex}
@@ -53,17 +55,18 @@ export const Avatar = ({
         </RadixAvatar.Fallback>
       </RadixAvatar.Root>
       {size != 'extra small' && statusType && <Status className={styles.Status} type={statusType} />}
-      {size != 'extra small' && badgeContent && <AvatarBadge badgeContent={badgeContent} />}
+      {size != 'extra small' && badgeContent && <AvatarBadge badgeContent={badgeContent} isRaised={isRaised} />}
     </div>
   );
 };
 
 interface StatusBadgeTypeProps {
   badgeContent: AvatarProps['badgeContent'];
+  isRaised?: AvatarProps['isRaised'];
 }
 
-const AvatarBadge = ({ badgeContent }: StatusBadgeTypeProps) => {
-  return <div className={styles.Badge}> {badgeContent}</div>;
+const AvatarBadge = ({ badgeContent, isRaised }: StatusBadgeTypeProps) => {
+  return <div className={classNames(styles.Badge, { [styles.isRaised]: isRaised })}> {badgeContent}</div>;
 };
 
 /**


### PR DESCRIPTION
- adds `isRaised` boolean to the `Avatar` props.


This ensures that the raised style is only applied if set.