### PR TITLE
feat(dropdown menu items): apply spacing styles to dropdown menu items

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.scss
+++ b/src/components/DropdownMenu/DropdownMenu.scss
@@ -14,11 +14,10 @@
   @include glass-materials-flat-thick;
   @include glass-shadows-and-blur;
 
-  width: 256px;
-  padding: 8px;
-
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
+  padding: 8px;
   border-radius: 8px;
 
   transform-origin: var(--radix-dropdown-menu-content-transform-origin);
@@ -26,8 +25,26 @@
   .zui-dropdown-item {
     @include glass-text-primary-color;
 
-    padding: 16px;
+    display: flex;
+    align-items: center;
+    font-weight: 400;
     outline: none;
+    border-radius: 8px;
+    user-select: none;
+    cursor: pointer;
+    align-self: stretch;
+
+    &.spacious {
+      padding: 16px;
+      font-size: 16px;
+      line-height: 24px;
+    }
+
+    &.compact {
+      padding: 8px 16px 8px 8px;
+      font-size: 14px;
+      line-height: 20px;
+    }
 
     &:hover {
       @include glass-state-hover-color;
@@ -36,10 +53,6 @@
     &:active {
       background: rgba(163, 162, 163, 0.1);
     }
-
-    border-radius: 8px;
-    user-select: none;
-    cursor: pointer;
   }
 
   .zui-dropdown-arrow {

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -114,6 +114,24 @@ describe('<DropdownMenu />', () => {
       mockRadixItem.mock.lastCall[0].onSelect();
       expect(mockOnSelect).toBeCalledTimes(1);
     });
+
+    test('should apply the compact class to menu items if size is compact', () => {
+      render(<DropdownMenu {...DEFAULT_PROPS} itemSize="compact" />);
+
+      const items = screen.getAllByText(/Dropdown Item/);
+      items.forEach(item => {
+        expect(item).toHaveClass('compact');
+      });
+    });
+
+    test('should apply the spacious class to menu items if size is spacious', () => {
+      render(<DropdownMenu {...DEFAULT_PROPS} itemSize="spacious" />);
+
+      const items = screen.getAllByText(/Dropdown Item/);
+      items.forEach(item => {
+        expect(item).toHaveClass('spacious');
+      });
+    });
   });
 
   describe('dropdown trigger', () => {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -15,6 +15,8 @@ import './DropdownMenu.scss';
 
 import classNames from 'classnames';
 
+type SizeType = 'compact' | 'spacious';
+
 export interface DropdownItem {
   /** Unique ID to use in Array.map() */
   id: string;
@@ -46,6 +48,7 @@ export interface DropdownMenuProps {
   /** Class to apply to the menu */
   menuClassName?: string;
   showArrow?: boolean;
+  itemSize?: SizeType;
 }
 
 export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
@@ -60,7 +63,8 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       open,
       defaultOpen,
       onOpenChange,
-      showArrow
+      showArrow,
+      itemSize = 'compact'
     },
     ref
   ) => {
@@ -81,7 +85,7 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
             {alignMenu === 'center' && showArrow && <RadixUIDropdownMenuArrow className="zui-dropdown-arrow" />}
             {items.map(item => (
               <RadixUIDropdownMenuItem
-                className={classNames('zui-dropdown-item', item.className)}
+                className={classNames('zui-dropdown-item', item.className, itemSize)}
                 key={item.id}
                 onSelect={(event: Event) => item.onSelect(event)}
               >


### PR DESCRIPTION
- applies `compact` and `spacious` styles to the dropdown menu items.

Compact
<img width="445" alt="Screenshot 2023-12-19 at 13 13 41" src="https://github.com/zer0-os/zUI/assets/39112648/0a8ea111-cd7b-44ba-8277-95b76c5accd8">
Spacious
<img width="445" alt="Screenshot 2023-12-19 at 13 13 37" src="https://github.com/zer0-os/zUI/assets/39112648/a98c59d0-feb4-4869-8a63-55d55e619820">
