### PR TITLE
Update Icon Button sizes for "large" | "small" | "x-small"

### DIFF
--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -110,7 +110,7 @@ describe('IconButton', () => {
     });
 
     describe('Icon Sizes', () => {
-      it('has an offset of 8px for the icon when the value of the size attribute is greater than 16px', () => {
+      it('has an offset of 12px for the icon when the value of the size attribute is greater than 24px', () => {
         renderComponent({
           Icon: IconXClose,
           label: 'the-label',
@@ -120,7 +120,7 @@ describe('IconButton', () => {
 
         expect(iconRender).toHaveBeenLastCalledWith({
           label: 'the-label',
-          size: 50,
+          size: 46,
           isFilled: false
         });
       });
@@ -150,7 +150,7 @@ describe('IconButton', () => {
 
         expect(iconRender).toHaveBeenLastCalledWith({
           label: 'the-label',
-          size: 32, // 40 (button size) - 8 (offset) = 32 (icon size)
+          size: 28, // 40 (button size) - 12 (offset) = 28 (icon size)
           isFilled: false
         });
       });
@@ -165,7 +165,7 @@ describe('IconButton', () => {
 
         expect(iconRender).toHaveBeenLastCalledWith({
           label: 'the-label',
-          size: 24, // 32 (button size) - 8 (offset) = 24 (icon size)
+          size: 20, // 32 (button size) - 12 (offset) = 20 (icon size)
           isFilled: false
         });
       });
@@ -180,7 +180,7 @@ describe('IconButton', () => {
 
         expect(iconRender).toHaveBeenLastCalledWith({
           label: 'the-label',
-          size: 16, // 24 (button size) - 8 (offset) = 16 (icon size)
+          size: 14, // 24 (button size) - 10 (offset) = 14 (icon size)
           isFilled: false
         });
       });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -38,7 +38,15 @@ const getSize = (size: IconButtonProperties['size'], forIcon = false): string | 
   }
 
   if (forIcon && baseSize !== undefined) {
-    const offset = baseSize <= 16 ? 4 : 8;
+    let offset;
+    if (baseSize <= 16) {
+      offset = 4;
+    } else if (baseSize <= 24) {
+      offset = 10;
+    } else {
+      offset = 12;
+    }
+
     return baseSize - offset;
   }
 


### PR DESCRIPTION
Updates the sizes of icon button as per the rules mentioned [here](https://wilderworld.atlassian.net/browse/ZOS-836?atlOrigin=eyJpIjoiMDRiMDFmZmZjMWVlNDE0NGFjMjAyMDEyZjc3YWUxZmIiLCJwIjoiaiJ9) in figma:
```
Where Size=Small(24) and Fill=true, the icon size has been reduced from 16x16px to 14x14px

Where Size=Regular(32px) and Fill=true, the icon size has been reduced from 24x24px to 20x20px

Where Size=Large(40px) and Fill=true, the icon size has been reduced from 32x32px to 28x28px
```

NOTE: The offset for custom size of the icon (`<=16`) is still 4. 