### PR TITLE
feat: remove stroke width from info circle icon

### DIFF
--- a/src/components/Icons/icons/IconInfoCircle.tsx
+++ b/src/components/Icons/icons/IconInfoCircle.tsx
@@ -32,7 +32,6 @@ export const IconInfoCircle = ({
             <path
               d="M12 8H12.01M12 16.5V11.5M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
               stroke={color}
-              strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
             />


### PR DESCRIPTION
- remove stroke width from info circle icon to align with stroke width of other icons

before:
<img width="195" alt="Screenshot 2024-01-10 at 13 14 29" src="https://github.com/zer0-os/zUI/assets/39112648/7fab9380-1e27-48f4-9d20-e99058842d29">

after:
<img width="195" alt="Screenshot 2024-01-10 at 13 14 40" src="https://github.com/zer0-os/zUI/assets/39112648/50550521-dbf6-4a1a-a061-e4aa48ddbd6d">
