### PR TITLE
Update input container min-width to `16rem`

### DIFF
--- a/src/components/SelectInput/SelectInput.module.scss
+++ b/src/components/SelectInput/SelectInput.module.scss
@@ -2,7 +2,7 @@
 @import '../../styles/theme';
 
 .InputContainer {
-  min-width: 15rem;
+  min-width: 16rem;
   text-align: left;
 
   .WrapperOpen {


### PR DESCRIPTION
Required for displaying the correct width of the dropdown in edit-profile modal (for selecting primary zid)

<img width="297" alt="image" src="https://github.com/zer0-os/zUI/assets/33264364/d4367237-914b-4c2b-aec2-bddc58352c3c">
