### PR TITLE
feat: add input border error state

### DIFF
--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -52,8 +52,7 @@
     }
 
     &[data-status='error'] {
-      border: 1px solid;
-      border-color: $color-failure-11;
+      border: 1px solid $color-failure-11;
 
       &:focus-within {
         border-color: $color-failure-9;

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -52,7 +52,8 @@
     }
 
     &[data-status='error'] {
-      border-color: $color-failure-8;
+      border: 1px solid;
+      border-color: $color-failure-11;
 
       &:focus-within {
         border-color: $color-failure-9;


### PR DESCRIPTION
- adds missing border when input is in error state

<img width="356" alt="Screenshot 2024-02-29 at 09 44 20" src="https://github.com/zer0-os/zUI/assets/39112648/cec16612-12fe-4df2-8366-970ebbf1af04">
