### PR TITLE
Remove slide up animation from `Accordion`

### DIFF
--- a/src/components/Accordion/Accordion.module.scss
+++ b/src/components/Accordion/Accordion.module.scss
@@ -141,7 +141,8 @@ $group-border-radius: 0.5rem;
     }
 
     &[data-state='closed'] {
-      animation: slideUp 200ms cubic-bezier(0.87, 0, 0.13, 1);
+      animation: none;
+      //animation: slideUp 200ms cubic-bezier(0.87, 0, 0.13, 1);
     }
   }
 


### PR DESCRIPTION
**NOTE**: This is a temporary change

Currently we're having issue when using accordion in zOS in the backup-faq modal. You can open a question, but when you "close" it, then the slideUp animation is not working. 

This PR temporarily removes it, until we get the animation working. 