### PR TITLE
feat(alert): remove background colour

### DIFF
--- a/src/components/Alert/Alert.module.scss
+++ b/src/components/Alert/Alert.module.scss
@@ -12,21 +12,17 @@
 
   &[data-variant='success'] {
     color: $color-success-11;
-    background-color: $color-success-4;
   }
 
   &[data-variant='error'] {
     color: $color-failure-11;
-    background-color: $color-failure-4;
   }
 
   &[data-variant='warning'] {
     color: $color-warning-11;
-    background-color: $color-warning-4;
   }
 
   &[data-variant='info'] {
     color: $color-primary-11;
-    background-color: $color-primary-4;
   }
 }


### PR DESCRIPTION
Removes the set background colour on the different Alert variants. If a filled background is required this can be added where the Alert is being imported. Due to latest design updates, in most cases, the filled background is no longer required.

<img width="547" alt="Screenshot 2024-04-26 at 11 31 40" src="https://github.com/zer0-os/zUI/assets/39112648/68577f30-d25c-465a-b32a-79dbc37c744a">
<img width="547" alt="Screenshot 2024-04-26 at 11 31 47" src="https://github.com/zer0-os/zUI/assets/39112648/cd04fafc-6242-4206-a80a-57ae99070a01">
<img width="547" alt="Screenshot 2024-04-26 at 11 31 53" src="https://github.com/zer0-os/zUI/assets/39112648/c93213dc-4462-49a8-9ed3-796675d018d9">
<img width="547" alt="Screenshot 2024-04-26 at 11 32 00" src="https://github.com/zer0-os/zUI/assets/39112648/99d9d56f-99ec-4ff0-9f2f-a32ce85b8b2a">
