### PR TITLE
feat(alert): apply isFilled prop to improve handling of background colour

### DIFF
--- a/src/components/Alert/Alert.module.scss
+++ b/src/components/Alert/Alert.module.scss
@@ -25,4 +25,22 @@
   &[data-variant='info'] {
     color: $color-primary-11;
   }
+
+  &.isFilled {
+    &[data-variant='success'] {
+      background-color: $color-success-4;
+    }
+
+    &[data-variant='error'] {
+      background-color: $color-failure-4;
+    }
+
+    &[data-variant='warning'] {
+      background-color: $color-warning-4;
+    }
+
+    &[data-variant='info'] {
+      background-color: $color-primary-4;
+    }
+  }
 }

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -5,7 +5,8 @@ import { Alert, AlertProps } from './';
 
 const DEFAULT_PROPS: AlertProps = {
   children: '',
-  variant: 'success'
+  variant: 'success',
+  isFilled: false
 };
 
 jest.mock('../Icons', () => ({
@@ -23,6 +24,11 @@ describe('<Alert />', () => {
   test('should render children', () => {
     const { container } = render(<Alert {...DEFAULT_PROPS}>mock children</Alert>);
     expect(container.firstChild).toHaveTextContent('mock children');
+  });
+
+  test('should apply isFilled', () => {
+    const { container } = render(<Alert {...DEFAULT_PROPS} isFilled />);
+    expect(container.firstChild).toHaveClass('isFilled');
   });
 
   describe('icons', () => {

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -11,11 +11,12 @@ export interface AlertProps {
   className?: string;
   variant?: AlertVariant;
   children?: ReactNode;
+  isFilled?: boolean;
 }
 
-export const Alert = ({ className, variant, children }: AlertProps) => {
+export const Alert = ({ className, variant, children, isFilled = false }: AlertProps) => {
   return (
-    <div className={classNames(styles.Container, className)} data-variant={variant}>
+    <div className={classNames(styles.Container, { [styles.isFilled]: isFilled }, className)} data-variant={variant}>
       {IconVariant[variant]}
       <div>{children}</div>
     </div>


### PR DESCRIPTION
- Decided to add an `isFilled` prop to the alert to improve the handling of background colours for the component. This means that where imported, styles shouldn't need to be applied for the background, but instead the developer can apply the `isFilled` flag