### PR TITLE
refactor(alert): update success colour

### DIFF
--- a/src/components/Alert/Alert.module.scss
+++ b/src/components/Alert/Alert.module.scss
@@ -11,7 +11,7 @@
   border-radius: 0.5rem;
 
   &[data-variant='success'] {
-    color: $color-success-11;
+    color: $color-secondary-11;
   }
 
   &[data-variant='error'] {
@@ -28,7 +28,7 @@
 
   &.isFilled {
     &[data-variant='success'] {
-      background-color: $color-success-4;
+      background-color: $color-secondary-4;
     }
 
     &[data-variant='error'] {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -66,7 +66,7 @@ export const Avatar = ({
           alt="avatar"
           onLoad={handleImageLoaded}
         />
-        <RadixAvatar.Fallback className={classNames(styles.Fallback, { [styles.isLoaded]: isLoaded })} delayMs={500}>
+        <RadixAvatar.Fallback className={classNames(styles.Fallback, { [styles.isLoaded]: isLoaded })}>
           <div className={classNames(styles.DefaultIcon, { [styles.isGroup]: isGroup })}>{renderDefaultIcon()}</div>
         </RadixAvatar.Fallback>
       </RadixAvatar.Root>


### PR DESCRIPTION
- updates success colour to the standard highlight colour used for zOS.

<img width="286" alt="Screenshot 2024-04-29 at 09 00 09" src="https://github.com/zer0-os/zUI/assets/39112648/07bfe19d-2f2a-4481-a713-da81d5ff191a">
