### PR TITLE
feat: add menuWidth for dropdown menu/select input

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -49,6 +49,7 @@ export interface DropdownMenuProps {
   menuClassName?: string;
   showArrow?: boolean;
   itemSize?: SizeType;
+  menuWidth?: number;
 }
 
 export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
@@ -64,7 +65,8 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
       defaultOpen,
       onOpenChange,
       showArrow,
-      itemSize = 'compact'
+      itemSize = 'compact',
+      menuWidth
     },
     ref
   ) => {
@@ -81,6 +83,7 @@ export const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
             align={alignMenu}
             side={side}
             ref={ref}
+            style={{ width: menuWidth }}
           >
             {alignMenu === 'center' && showArrow && <RadixUIDropdownMenuArrow className="zui-dropdown-arrow" />}
             {items.map(item => (

--- a/src/components/SelectInput/SelectInput.tsx
+++ b/src/components/SelectInput/SelectInput.tsx
@@ -20,6 +20,7 @@ export type SelectInputProps = {
   error?: boolean;
   itemSize: 'compact' | 'spacious';
   menuClassName?: string;
+  menuWidth?: number;
 };
 
 export const SelectInput: FC<SelectInputProps> = ({
@@ -31,7 +32,8 @@ export const SelectInput: FC<SelectInputProps> = ({
   alert,
   error = false,
   itemSize = 'compact',
-  menuClassName
+  menuClassName,
+  menuWidth
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -57,7 +59,7 @@ export const SelectInput: FC<SelectInputProps> = ({
       error={error}
       endEnhancer={<IconChevronDown size={16} />}
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      onChange={() => { }}
+      onChange={() => {}}
     />
   );
 
@@ -69,6 +71,7 @@ export const SelectInput: FC<SelectInputProps> = ({
       open={isOpen}
       onOpenChange={onOpenChange}
       itemSize={itemSize}
+      menuWidth={menuWidth}
     />
   );
 };


### PR DESCRIPTION
Add menuWidth property for dropdown menu/select input to control width of the dropdown menu. This isn't the ideal solution but will do for now as a quick update to control width of these dropdowns in zos