### PR TITLE
chore: bump version (`1.17.0`) -> (`1.18.0`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zero-tech/zui",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Zero UI React Component Library",
   "scripts": {
     "about:clean": "echo 'Removes any existing build folders.'",


### PR DESCRIPTION
- chore: bump version (`1.17.0`) -> (`1.18.0`)
