### PR TITLE
Fix accidental includes added to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*", "vitest.config.ts", "src/test/setup.ts", ".storybook/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "dist-storybook", "build", "**/*.js", "**.config.js"]
 }


### PR DESCRIPTION
The TSConfig had a few extra includes that weren't necessary, causing some extra source map files to be deployed to npm.