### PR TITLE
Replace radix avatar with html components

### DIFF
--- a/src/components/Avatar/Avatar.module.scss
+++ b/src/components/Avatar/Avatar.module.scss
@@ -68,6 +68,16 @@
     height: 100%;
     object-fit: cover;
     border-radius: inherit;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: theme.$color-secondary-11;
+    }
   }
 
   .Fallback {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import * as RadixAvatar from '@radix-ui/react-avatar';
+import React, { memo, useState } from 'react';
 
 import { Status } from '../Status';
 import { IconCurrencyEthereum, IconUsers1 } from '../Icons';
@@ -21,43 +20,57 @@ export interface AvatarProps {
   isGroup?: boolean;
 }
 
-export const Avatar = ({
-  className,
-  size = 'regular',
-  imageURL,
-  statusType,
-  badgeContent,
-  isActive,
-  isRaised,
-  tabIndex = 0,
-  isGroup = false
-}: AvatarProps) => {
-  const renderDefaultIcon = () => {
-    if (isGroup) {
-      return <IconUsers1 size={AVATAR_ICON_SIZE[size]} />;
-    } else {
-      return <IconCurrencyEthereum size={AVATAR_ICON_SIZE[size]} />;
-    }
-  };
+export const Avatar = memo(
+  ({
+    className,
+    size = 'regular',
+    imageURL,
+    statusType,
+    badgeContent,
+    isActive,
+    isRaised,
+    tabIndex = 0,
+    isGroup = false
+  }: AvatarProps) => {
+    const renderDefaultIcon = () => {
+      if (isGroup) {
+        return <IconUsers1 size={AVATAR_ICON_SIZE[size]} />;
+      } else {
+        return <IconCurrencyEthereum size={AVATAR_ICON_SIZE[size]} />;
+      }
+    };
 
-  return (
-    <div
-      className={classNames(styles.Avatar, { [styles.isActive]: isActive, [styles.isRaised]: isRaised }, className)}
-      data-size={size}
-      tabIndex={tabIndex}
-    >
-      <RadixAvatar.Root className={styles.Root}>
-        <RadixAvatar.Image className={styles.Image} src={imageURL} alt="avatar" />
+    const [renderFallback, setRenderFallback] = useState(!imageURL);
+    const handleError = () => {
+      setRenderFallback(true);
+    };
+    const handleLoad = () => {
+      setRenderFallback(false);
+    };
 
-        <RadixAvatar.Fallback className={styles.Fallback} delayMs={imageURL ? 500 : 0}>
-          <div className={classNames(styles.DefaultIcon, { [styles.isGroup]: isGroup })}>{renderDefaultIcon()}</div>
-        </RadixAvatar.Fallback>
-      </RadixAvatar.Root>
-      {size != 'extra small' && statusType && <Status className={styles.Status} type={statusType} />}
-      {size != 'extra small' && badgeContent && <AvatarBadge badgeContent={badgeContent} />}
-    </div>
-  );
-};
+    return (
+      <div
+        className={classNames(styles.Avatar, { [styles.isActive]: isActive, [styles.isRaised]: isRaised }, className)}
+        data-size={size}
+        tabIndex={tabIndex}
+      >
+        <div className={styles.Root}>
+          {renderFallback ? (
+            <span className={styles.Fallback}>
+              <div className={classNames(styles.DefaultIcon, { [styles.isGroup]: isGroup })}>{renderDefaultIcon()}</div>
+            </span>
+          ) : (
+            <img className={styles.Image} src={imageURL} alt="" onError={handleError} onLoad={handleLoad} />
+          )}
+        </div>
+        {size != 'extra small' && statusType && <Status className={styles.Status} type={statusType} />}
+        {size != 'extra small' && badgeContent && <AvatarBadge badgeContent={badgeContent} />}
+      </div>
+    );
+  }
+);
+
+Avatar.displayName = 'Avatar';
 
 interface StatusBadgeTypeProps {
   badgeContent: AvatarProps['badgeContent'];


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [ ] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. What is the old behaviour? (if applicable)

<!-- Please describe the old behaviour that you are modifying. If this PR adds new functionality, leave blank! -->
Replaces the avatar implementation using Radix Avatar with html components

## 3. What is the new behaviour?
Radix would always mark the image as "loading" on every render, which causes the image to un-render, then re-render, even if the url hasn't changed. This can cause flickering, even though the browser has cached the image.
The reason they do this is to make the fallback smoothly load in if there is an error fetching the image, but this is a minority case and not the majority, so I've switched up the logic.

Now if there is an error, there is an ::after element that will appear, covering the broken image icon, then the fallback will render and the image covered broken image logo will disappear.

<!-- Please describe the behaviour or changes that are being added by this PR. -->

## 4. How can this behaviour be tested? (if applicable)

## 5. Other information

<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
